### PR TITLE
feat: Handle cases where export target are modified

### DIFF
--- a/src/Connector.AzureDataLake/AzureDataLakeConstants.cs
+++ b/src/Connector.AzureDataLake/AzureDataLakeConstants.cs
@@ -8,6 +8,8 @@ namespace CluedIn.Connector.AzureDataLake
 {
     public class AzureDataLakeConstants : ConfigurationConstantsBase, IAzureDataLakeConstants
     {
+        public static readonly Guid DataLakeProviderId = Guid.Parse("F6178E19-7168-449C-B4B6-F9810E86C1C2");
+
         public const string AccountName = nameof(AccountName);
         public const string AccountKey = nameof(AccountKey);
         public const string FileSystemName = nameof(FileSystemName);
@@ -45,7 +47,7 @@ namespace CluedIn.Connector.AzureDataLake
             [JobScheduleNames.Never] = "0 5 31 2 *",
         };
 
-        public AzureDataLakeConstants(ApplicationContext applicationContext) : base(Guid.Parse("F6178E19-7168-449C-B4B6-F9810E86C1C2"),
+        public AzureDataLakeConstants(ApplicationContext applicationContext) : base(DataLakeProviderId,
             providerName: "Azure DataLake Connector",
             componentName: "AzureDataLakeConnector",
             icon: "Resources.azuredatalake.svg",

--- a/src/Connector.AzureDataLake/Connector/AzureDataLakeExportEntitiesJob.cs
+++ b/src/Connector.AzureDataLake/Connector/AzureDataLakeExportEntitiesJob.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -15,9 +16,9 @@ using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.AzureDataLake.Connector;
 
-internal class ExportEntitiesJob : AzureDataLakeJobBase
+internal class AzureDataLakeExportEntitiesJob : AzureDataLakeJobBase
 {
-    public ExportEntitiesJob(ApplicationContext appContext) : base(appContext)
+    public AzureDataLakeExportEntitiesJob(ApplicationContext appContext) : base(appContext)
     {
     }
 
@@ -33,7 +34,6 @@ internal class ExportEntitiesJob : AzureDataLakeJobBase
         var client = context.ApplicationContext.Container.Resolve<IAzureDataLakeClient>();
         var organizationProviderDataStore = context.Organization.DataStores.GetDataStore<ProviderDefinition>();
 
-
         var streamId = new Guid(args.Message);
         var streamModel = await streamRepository.GetStream(streamId);
 
@@ -43,6 +43,15 @@ internal class ExportEntitiesJob : AzureDataLakeJobBase
         if (provider == null)
         {
             context.Log.LogDebug("Unable to get provider {ProviderDefinitionId}. Skipping export.", providerDefinitionId);
+            return;
+        }
+
+        if (provider.ProviderId != AzureDataLakeConstants.DataLakeProviderId)
+        {
+            context.Log.LogDebug(
+                "ProviderId {ProviderDefinitionId} is not the expected {DataLakeProviderId}. Skipping export.",
+                provider.ProviderId,
+                AzureDataLakeConstants.DataLakeProviderId);
             return;
         }
 

--- a/src/Connector.AzureDataLake/InstallComponents.cs
+++ b/src/Connector.AzureDataLake/InstallComponents.cs
@@ -9,7 +9,7 @@ namespace CluedIn.Connector.AzureDataLake
     {
         public void Install(IWindsorContainer container, IConfigurationStore store)
         {
-            container.Register(Component.For<ExportEntitiesJob>().ImplementedBy<ExportEntitiesJob>().OnlyNewServices());
+            container.Register(Component.For<AzureDataLakeExportEntitiesJob>().ImplementedBy<AzureDataLakeExportEntitiesJob>().OnlyNewServices());
             container.Register(Component.For<IAzureDataLakeClient>().ImplementedBy<AzureDataLakeClient>().OnlyNewServices());
             container.Register(Component.For<IAzureDataLakeConstants>().ImplementedBy<AzureDataLakeConstants>().LifestyleSingleton());
         }

--- a/src/Connector.AzureDataLake/UpdateExportTargetEventHandler.cs
+++ b/src/Connector.AzureDataLake/UpdateExportTargetEventHandler.cs
@@ -14,8 +14,8 @@ internal class UpdateExportTargetEventHandler : UpdateStreamScheduleBase, IDispo
     private readonly IDisposable _subscription;
     private bool _disposedValue;
 
-    public UpdateExportTargetEventHandler(ApplicationContext applicationContext)
-        : base(applicationContext)
+    public UpdateExportTargetEventHandler(ApplicationContext applicationContext, Guid providerId)
+        : base(applicationContext, providerId)
     {
         _subscription = ApplicationContext.System.Events.Local.Subscribe<UpdateExportTargetEvent>(ProcessEvent);
     }

--- a/src/Connector.AzureDataLake/UpdateStreamEventHandler.cs
+++ b/src/Connector.AzureDataLake/UpdateStreamEventHandler.cs
@@ -9,15 +9,15 @@ using Newtonsoft.Json.Linq;
 
 namespace CluedIn.Connector.AzureDataLake;
 
-internal class ChangeStreamStateEventHandler : UpdateStreamScheduleBase, IDisposable
+internal class UpdateStreamEventHandler : UpdateStreamScheduleBase, IDisposable
 {
     private readonly IDisposable _subscription;
     private bool _disposedValue;
 
-    public ChangeStreamStateEventHandler(ApplicationContext applicationContext, Guid providerId)
+    public UpdateStreamEventHandler(ApplicationContext applicationContext, Guid providerId)
         : base(applicationContext, providerId)
     {
-        _subscription = ApplicationContext.System.Events.Local.Subscribe<ChangeStreamStateEvent>(ProcessEvent);
+        _subscription = ApplicationContext.System.Events.Local.Subscribe<UpdateStreamEvent>(ProcessEvent);
     }
 
     protected virtual void Dispose(bool disposing)
@@ -34,11 +34,11 @@ internal class ChangeStreamStateEventHandler : UpdateStreamScheduleBase, IDispos
     }
 
 
-    private void ProcessEvent(ChangeStreamStateEvent eventData)
+    private void ProcessEvent(UpdateStreamEvent eventData)
     {
         ProcessEventAsync(eventData).GetAwaiter().GetResult();
     }
-    private async Task ProcessEventAsync(ChangeStreamStateEvent eventData)
+    private async Task ProcessEventAsync(UpdateStreamEvent eventData)
     {
         if (!(eventData.EventData?.StartsWith("{") ?? false))
         {

--- a/src/Connector.AzureDataLake/UpdateStreamScheduleBase.cs
+++ b/src/Connector.AzureDataLake/UpdateStreamScheduleBase.cs
@@ -1,10 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using CluedIn.Connector.AzureDataLake.Connector;
 using CluedIn.Core;
+using CluedIn.Core.Data.Relational;
 using CluedIn.Core.Jobs;
+using CluedIn.Core.Providers;
 using CluedIn.Core.Streams;
 using CluedIn.Core.Streams.Models;
 
@@ -15,29 +18,67 @@ namespace CluedIn.Connector.AzureDataLake;
 internal abstract class UpdateStreamScheduleBase
 {  
     private readonly ApplicationContext _applicationContext;
+    private readonly Guid _providerId;
 
     protected ApplicationContext ApplicationContext => _applicationContext;
 
-    protected UpdateStreamScheduleBase(ApplicationContext applicationContext)
+    protected UpdateStreamScheduleBase(ApplicationContext applicationContext, Guid providerId)
     {
         _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
+        _providerId = providerId;
     }
 
     protected async Task UpdateStreamSchedule(ExecutionContext executionContext, StreamModel stream)
     {
         var jobServerClient = ApplicationContext.Container.Resolve<IJobServerClient>();
-        var exportJob = ApplicationContext.Container.Resolve<ExportEntitiesJob>();
+        var exportJob = ApplicationContext.Container.Resolve<AzureDataLakeExportEntitiesJob>();
+        var hasExistingJob = HasExistingJob(jobServerClient, stream);
+        if (!await IsDataLakeProvider(executionContext, stream))
+        {
+            if (hasExistingJob)
+            {
+                var neverCron = AzureDataLakeConstants.CronSchedules[AzureDataLakeConstants.JobScheduleNames.Never];
+                exportJob.Schedule(jobServerClient, neverCron, stream.Id.ToString());
+            }
+            return;
+        }
+
         var cronSchedule = await GetCronSchedule(executionContext, stream);
         exportJob.Schedule(jobServerClient, cronSchedule, stream.Id.ToString());
     }
 
-    private static async Task<string> GetCronSchedule(ExecutionContext context, StreamModel stream)
+    private bool HasExistingJob(IJobServerClient jobServerClient, StreamModel stream)
     {
-        if (!stream.ConnectorProviderDefinitionId.HasValue)
+        var allJobs = jobServerClient.GetAllRecurringJobs();
+        if (allJobs.Any(jobId => jobId == $"CustomScheduledJob|{typeof(AzureDataLakeExportEntitiesJob).FullName}|{stream.Id}"))
         {
-            return AzureDataLakeConstants.CronSchedules[AzureDataLakeConstants.JobScheduleNames.Never];
+            return true;
         }
 
+        return false;
+    }
+
+    private async Task<bool> IsDataLakeProvider(ExecutionContext executionContext, StreamModel stream)
+    {
+        if (stream.ConnectorProviderDefinitionId == null)
+        {
+            return false;
+        }
+
+
+        var organizationProviderDataStore = executionContext.Organization.DataStores.GetDataStore<ProviderDefinition>();
+        var provider = await organizationProviderDataStore.GetByIdAsync(executionContext, stream.ConnectorProviderDefinitionId.Value);
+
+        if (provider == null)
+        {
+            return false;
+        }
+
+        return provider.ProviderId == _providerId;
+    }
+
+    private static async Task<string> GetCronSchedule(ExecutionContext context, StreamModel stream)
+    {
         var containerName = stream.ContainerName;
         var providerDefinitionId = stream.ConnectorProviderDefinitionId.Value;
         var configurations = await AzureDataLakeConnectorJobData.Create(context, providerDefinitionId, containerName);

--- a/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
+++ b/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
@@ -589,7 +589,7 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
 
             var providerDefinition = new Mock<IRelationalDataStore<ProviderDefinition>>();
             providerDefinition.Setup(store => store.GetByIdAsync(It.IsAny<ExecutionContext>(), providerDefinitionId))
-                .ReturnsAsync(new ProviderDefinition {  IsEnabled = true });
+                .ReturnsAsync(new ProviderDefinition {  IsEnabled = true, ProviderId = AzureDataLakeConstants.DataLakeProviderId });
             container.Register(Component.For<IRelationalDataStore<ProviderDefinition>>()
                 .Instance(providerDefinition.Object));
 
@@ -733,7 +733,7 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
 
                 Assert.Equal(1, total);
 
-                var exportJob = new ExportEntitiesJob(applicationContext);
+                var exportJob = new AzureDataLakeExportEntitiesJob(applicationContext);
                 exportJob.Run(new Core.Jobs.JobArgs
                 {
                     OrganizationId = organization.Id.ToString(),


### PR DESCRIPTION
## Description
Work Item ID: [AB#33228](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/33228)
Handle cases where export target are updated from datalake => non datalake or from 1 datalake to another datalake.

I renamed the ExportEntitiesJob in anticipation of refactor that allow OneLake