### PR TITLE
Revert "fix: Change path to mssql-tools and ignore certificate (#51)"

### DIFF
--- a/build/integration-test.ps1
+++ b/build/integration-test.ps1
@@ -62,8 +62,8 @@ function Run-Setup() {
 	# Wait for additional 5 seconds to make sure it's really ready
 	Start-Sleep 5
 	$createDatabaseCommand = "CREATE DATABASE [$databaseName]"
-	Write-Host "##[command]docker exec $containerName /opt/mssql-tools18/bin/sqlcmd -S $databaseHost -U $databaseUser -P $databasePassword -C -Q $createDatabaseCommand"
-	docker exec $containerName /opt/mssql-tools18/bin/sqlcmd -S $databaseHost -U $databaseUser -P $databasePassword -C -Q $createDatabaseCommand
+	Write-Host "##[command]docker exec $containerName /opt/mssql-tools/bin/sqlcmd -S $databaseHost -U $databaseUser -P $databasePassword -Q $createDatabaseCommand"
+	docker exec $containerName /opt/mssql-tools/bin/sqlcmd -S $databaseHost -U $databaseUser -P $databasePassword -Q $createDatabaseCommand
 }
 
 function Run-TearDown() {


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#37490](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/37490)

Revert path change of `mssql-tools`.

## How has it been tested? <!-- Remove if not needed -->
It hasn't