### PR TITLE
fix: Add Timestamp and Epoch to output

### DIFF
--- a/docs/4.3.1-release-notes.md
+++ b/docs/4.3.1-release-notes.md
@@ -1,0 +1,2 @@
+### Fixes
+- Reintroduce timestamps when the event was fired

--- a/src/Connector.AzureDataLake/Connector/AzureDataLakeConnector.cs
+++ b/src/Connector.AzureDataLake/Connector/AzureDataLakeConnector.cs
@@ -1,5 +1,6 @@
 ﻿using CluedIn.Connector.DataLake.Common.Connector;
 
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.AzureDataLake.Connector;
@@ -10,8 +11,9 @@ public class AzureDataLakeConnector : DataLakeConnector
         ILogger<AzureDataLakeConnector> logger,
         AzureDataLakeClient client,
         IAzureDataLakeConstants constants,
-        AzureDataLakeJobDataFactory dataLakeJobDataFactory)
-        : base(logger, client, constants, dataLakeJobDataFactory)
+        AzureDataLakeJobDataFactory dataLakeJobDataFactory,
+        ISystemClock systemClock)
+        : base(logger, client, constants, dataLakeJobDataFactory, systemClock)
     {
     }
 }

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -13,6 +13,7 @@ using CluedIn.Core.Processing;
 using CluedIn.Core.Streams.Models;
 
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 using Newtonsoft.Json;
@@ -28,6 +29,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         private const int TableCreationLockTimeoutInMillliseconds = 100;
         private readonly ILogger<DataLakeConnector> _logger;
         private readonly IDataLakeClient _client;
+        private readonly ISystemClock _systemClock;
         private readonly IDataLakeJobDataFactory _dataLakeJobDataFactory;
         private readonly PartitionedBuffer<IDataLakeJobData, string> _buffer;
         private static readonly JsonSerializerSettings _immediateOutputSerializerSettings = GetJsonSerializerSettings(Formatting.Indented);
@@ -55,11 +57,13 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             ILogger<DataLakeConnector> logger,
             IDataLakeClient client,
             IDataLakeConstants constants,
-            IDataLakeJobDataFactory dataLakeJobDataFactory)
+            IDataLakeJobDataFactory dataLakeJobDataFactory,
+            ISystemClock systemClock)
             : base(constants.ProviderId, false)
         {
             _logger = logger;
             _client = client;
+            _systemClock = systemClock;
             _dataLakeJobDataFactory = dataLakeJobDataFactory;
 
             var cacheRecordsThreshold = ConfigurationManagerEx.AppSettings.GetValue(constants.CacheRecordsThresholdKeyName, constants.CacheRecordsThresholdDefaultValue);
@@ -113,6 +117,16 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             AddToData("Codes", connectorEntityData.EntityCodes.SafeEnumerate().Select(code => code.ToString()));
             AddToData("ProviderDefinitionId", providerDefinitionId);
             AddToData("ContainerName", containerName);
+
+            if (!data.ContainsKey("Timestamp"))
+            {
+                AddToData("Timestamp", _systemClock.UtcNow.ToString("O"));
+            }
+
+            if (!data.ContainsKey("Epoch"))
+            {
+                AddToData("Epoch", _systemClock.UtcNow.ToUnixTimeMilliseconds());
+            }
 
             // end match previous version of the connector
             if (streamModel.ExportOutgoingEdges)
@@ -397,6 +411,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             {
                 TypeNameHandling = TypeNameHandling.None,
                 Formatting = formatting,
+                DateParseHandling = DateParseHandling.None,
             };
         }
 
@@ -530,7 +545,9 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 return;
             }
 
-            var content = JsonConvert.SerializeObject(entityData.Select(JObject.Parse).ToArray(), _immediateOutputSerializerSettings);
+            var content = JsonConvert.SerializeObject(
+                entityData.Select(x => (JObject)JsonConvert.DeserializeObject(x, _immediateOutputSerializerSettings)).ToArray(),
+                _immediateOutputSerializerSettings);
 
             var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH-mm-ss.fffffff");
             var fileName = $"{configuration.ContainerName}.{timestamp}.json";

--- a/src/Connector.OneLake/Connector/OneLakeConnector.cs
+++ b/src/Connector.OneLake/Connector/OneLakeConnector.cs
@@ -1,5 +1,6 @@
 ﻿using CluedIn.Connector.DataLake.Common.Connector;
 
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.OneLake.Connector;
@@ -10,8 +11,9 @@ public class OneLakeConnector : DataLakeConnector
         ILogger<OneLakeConnector> logger,
         OneLakeClient client,
         IOneLakeConstants constants,
-        OneLakeJobDataFactory dataLakeJobDataFactory)
-        : base(logger, client, constants, dataLakeJobDataFactory)
+        OneLakeJobDataFactory dataLakeJobDataFactory,
+        ISystemClock systemClock)
+        : base(logger, client, constants, dataLakeJobDataFactory, systemClock)
     {
     }
 }

--- a/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
+++ b/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
@@ -31,6 +31,7 @@ using CluedIn.Core.Streams.Models;
 using CsvHelper.Configuration;
 
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 using Moq;
@@ -62,6 +63,9 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
             var providerDefinitionId = Guid.Parse("c444cda8-d9b5-45cc-a82d-fef28e08d55c");
 
             var container = new WindsorContainer();
+
+            var mockClock = new Mock<ISystemClock>();
+            mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(2024, 8, 21, 3, 16, 0, TimeSpan.FromHours(5)));
 
             container.Register(Component.For<ILogger<OrganizationDataStores>>()
                 .Instance(new Mock<ILogger<OrganizationDataStores>>().Object));
@@ -105,7 +109,8 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                 new Mock<ILogger<AzureDataLakeConnector>>().Object,
                 new AzureDataLakeClient(),
                 azureDataLakeConstantsMock.Object,
-                jobDataFactory.Object
+                jobDataFactory.Object,
+                mockClock.Object
             );
 
             jobDataFactory.Setup(x => x.GetConfiguration(context, providerDefinitionId, It.IsAny<string>()  ))
@@ -186,6 +191,8 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                         ],
                         "ProviderDefinitionId": "c444cda8-d9b5-45cc-a82d-fef28e08d55c",
                         "ContainerName": "test",
+                        "Timestamp": "2024-08-21T03:16:00.0000000+05:00",
+                        "Epoch": 1724192160000,
                         "OutgoingEdges": [
                           {
                             "FromReference": {
@@ -333,6 +340,9 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
 
             var container = new WindsorContainer();
 
+            var mockClock = new Mock<ISystemClock>();
+            mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(2024, 8, 21, 3, 16, 0, TimeSpan.FromHours(5)));
+
             container.Register(Component.For<ILogger<OrganizationDataStores>>()
                 .Instance(new Mock<ILogger<OrganizationDataStores>>().Object));
 
@@ -375,7 +385,8 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                 new Mock<ILogger<AzureDataLakeConnector>>().Object,
                 new AzureDataLakeClient(),
                 azureDataLakeConstantsMock.Object,
-                jobDataFactory.Object
+                jobDataFactory.Object,
+                mockClock.Object
             );
 
             jobDataFactory.Setup(x => x.GetConfiguration(context, providerDefinitionId, It.IsAny<string>()))
@@ -455,6 +466,8 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                       ],
                       "ProviderDefinitionId": "c444cda8-d9b5-45cc-a82d-fef28e08d55c",
                       "ContainerName": "test",
+                      "Timestamp": "2024-08-21T03:16:00.0000000+05:00",
+                      "Epoch": 1724192160000,
                       "OutgoingEdges": [
                         {
                           "FromReference": {
@@ -620,6 +633,9 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
 
             var container = new WindsorContainer();
 
+            var mockClock = new Mock<ISystemClock>();
+            mockClock.Setup(x => x.UtcNow).Returns(new DateTimeOffset(2024, 8, 21, 3, 16, 0, TimeSpan.FromHours(5)));
+
             container.Register(Component.For<ILogger<OrganizationDataStores>>()
                 .Instance(new Mock<ILogger<OrganizationDataStores>>().Object));
             container.Register(Component.For<ILogger<ExecutionContext>>()
@@ -710,7 +726,8 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                 new Mock<ILogger<AzureDataLakeConnector>>().Object,
                 new AzureDataLakeClient(),
                 azureDataLakeConstantsMock.Object,
-                jobDataFactory.Object
+                jobDataFactory.Object,
+                mockClock.Object
             );
 
             jobDataFactory.Setup(x => x.GetConfiguration(It.IsAny<ExecutionContext>(), providerDefinitionId, It.IsAny<string>()))
@@ -856,6 +873,7 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                 ],
                 "ContainerName": "test",
                 "EntityType": "/Person",
+                "Epoch": 1724192160000,
                 "IncomingEdges": [
                   {
                     "FromReference": {
@@ -987,6 +1005,7 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                 "PersistHash": "etypzcezkiehwq8vw4oqog==",
                 "PersistVersion": 1,
                 "ProviderDefinitionId": "c444cda8-d9b5-45cc-a82d-fef28e08d55c",
+                "Timestamp": "2024-08-21T03:16:00.0000000+05:00",
                 "user.age": "123",
                 "user.dobInDateTime": "2000-01-02T03:04:05",
                 "user.dobInDateTimeOffset": "2000-01-02T03:04:05+12:34",
@@ -1004,9 +1023,9 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
 
             var sb = new StringBuilder();
             var dataLine =
-            sb.Append($"Id,Codes,ContainerName,EntityType,IncomingEdges,Name,OriginEntityCode,OutgoingEdges,PersistHash,PersistVersion,ProviderDefinitionId,user.age,user.dobInDateTime,user.dobInDateTimeOffset,user.lastName{csvConfig.NewLineString}");
+            sb.Append($"Id,Codes,ContainerName,EntityType,Epoch,IncomingEdges,Name,OriginEntityCode,OutgoingEdges,PersistHash,PersistVersion,ProviderDefinitionId,Timestamp,user.age,user.dobInDateTime,user.dobInDateTimeOffset,user.lastName{csvConfig.NewLineString}");
             sb.Append($$$"""
-            f55c66dc-7881-55c9-889f-344992e71cb8,"[""/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0""]",test,/Person,"[{""FromReference"":{""Code"":{""Origin"":{""Code"":""Acceptance"",""Id"":null},""Value"":""7c5591cf-861a-4642-861d-3b02485854a0"",""Key"":""/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""ToReference"":{""Code"":{""Origin"":{""Code"":""Somewhere"",""Id"":null},""Value"":""1234"",""Key"":""/EntityA#Somewhere:1234"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityA""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityA""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""EdgeType"":{""Root"":null,""Code"":""/EntityA""},""HasProperties"":false,""Properties"":{},""CreationOptions"":0,""Weight"":null,""Version"":0}]",Jean Luc Picard,/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0,"[{""FromReference"":{""Code"":{""Origin"":{""Code"":""Somewhere"",""Id"":null},""Value"":""5678"",""Key"":""/EntityB#Somewhere:5678"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityB""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityB""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""ToReference"":{""Code"":{""Origin"":{""Code"":""Acceptance"",""Id"":null},""Value"":""7c5591cf-861a-4642-861d-3b02485854a0"",""Key"":""/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""EdgeType"":{""Root"":null,""Code"":""/EntityB""},""HasProperties"":false,""Properties"":{},""CreationOptions"":0,""Weight"":null,""Version"":0}]",etypzcezkiehwq8vw4oqog==,1,c444cda8-d9b5-45cc-a82d-fef28e08d55c,123,2000-01-02T03:04:05,2000-01-02T03:04:05+12:34,Picard{{{csvConfig.NewLineString}}}
+            f55c66dc-7881-55c9-889f-344992e71cb8,"[""/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0""]",test,/Person,1724192160000,"[{""FromReference"":{""Code"":{""Origin"":{""Code"":""Acceptance"",""Id"":null},""Value"":""7c5591cf-861a-4642-861d-3b02485854a0"",""Key"":""/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""ToReference"":{""Code"":{""Origin"":{""Code"":""Somewhere"",""Id"":null},""Value"":""1234"",""Key"":""/EntityA#Somewhere:1234"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityA""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityA""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""EdgeType"":{""Root"":null,""Code"":""/EntityA""},""HasProperties"":false,""Properties"":{},""CreationOptions"":0,""Weight"":null,""Version"":0}]",Jean Luc Picard,/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0,"[{""FromReference"":{""Code"":{""Origin"":{""Code"":""Somewhere"",""Id"":null},""Value"":""5678"",""Key"":""/EntityB#Somewhere:5678"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityB""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/EntityB""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""ToReference"":{""Code"":{""Origin"":{""Code"":""Acceptance"",""Id"":null},""Value"":""7c5591cf-861a-4642-861d-3b02485854a0"",""Key"":""/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0"",""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""}},""Type"":{""IsEntityContainer"":false,""Root"":null,""Code"":""/Person""},""Name"":null,""Properties"":null,""PropertyCount"":null,""EntityId"":null,""IsEmpty"":false},""EdgeType"":{""Root"":null,""Code"":""/EntityB""},""HasProperties"":false,""Properties"":{},""CreationOptions"":0,""Weight"":null,""Version"":0}]",etypzcezkiehwq8vw4oqog==,1,c444cda8-d9b5-45cc-a82d-fef28e08d55c,2024-08-21T03:16:00.0000000+05:00,123,2000-01-02T03:04:05,2000-01-02T03:04:05+12:34,Picard{{{csvConfig.NewLineString}}}
             """);
 
             _testOutputHelper.WriteLine(content);
@@ -1044,6 +1063,7 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
             Codes ["/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0"]
             ContainerName test
             EntityType /Person
+            Epoch 1724192160000
             IncomingEdges [{"FromReference":{"Code":{"Origin":{"Code":"Acceptance","Id":null},"Value":"7c5591cf-861a-4642-861d-3b02485854a0","Key":"/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0","Type":{"IsEntityContainer":false,"Root":null,"Code":"/Person"}},"Type":{"IsEntityContainer":false,"Root":null,"Code":"/Person"},"Name":null,"Properties":null,"PropertyCount":null,"EntityId":null,"IsEmpty":false},"ToReference":{"Code":{"Origin":{"Code":"Somewhere","Id":null},"Value":"1234","Key":"/EntityA#Somewhere:1234","Type":{"IsEntityContainer":false,"Root":null,"Code":"/EntityA"}},"Type":{"IsEntityContainer":false,"Root":null,"Code":"/EntityA"},"Name":null,"Properties":null,"PropertyCount":null,"EntityId":null,"IsEmpty":false},"EdgeType":{"Root":null,"Code":"/EntityA"},"HasProperties":false,"Properties":{},"CreationOptions":0,"Weight":null,"Version":0}]
             Name Jean Luc Picard
             OriginEntityCode /Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0
@@ -1051,6 +1071,7 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
             PersistHash etypzcezkiehwq8vw4oqog==
             PersistVersion 1
             ProviderDefinitionId c444cda8-d9b5-45cc-a82d-fef28e08d55c
+            Timestamp 2024-08-21T03:16:00.0000000+05:00
             user.age 123
             user.dobInDateTime 2000-01-02T03:04:05
             user.dobInDateTimeOffset 2000-01-02T03:04:05+12:34
@@ -1065,7 +1086,11 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                     case LogicalTypeEnum.Uuid:
                         return columnReader.LogicalReader<Guid?>().ReadAll(groupNumRows).Single();
                     case LogicalTypeEnum.Int:
-                        return columnReader.LogicalReader<int?>().ReadAll(groupNumRows).Single();
+                        if (columnReader is ColumnReader<int>)
+                        {
+                            return columnReader.LogicalReader<int?>().ReadAll(groupNumRows).Single();
+                        }
+                        return columnReader.LogicalReader<long?>().ReadAll(groupNumRows).Single();
                     case LogicalTypeEnum.String:
                         return columnReader.LogicalReader<string>().ReadAll(groupNumRows).Single();
                     default:
@@ -1155,7 +1180,6 @@ namespace CluedIn.Connector.AzureDataLake.Tests.Integration
                     break;
                 }
             }
-
             return path;
         }
     }


### PR DESCRIPTION
## Description
Work Item ID: [AB#39983](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/39983)

This adds timestamp to all outputs (sync & event stream)


## How has it been tested?
Local cluedin

## Release Note
Add Timestamp & Epoch to output