### PR TITLE
fix: Use non empty string account id to prevent error when deactivating export target

### DIFF
--- a/src/Connector.AzureAIStudio/AzureAIStudioConnectorComponent.cs
+++ b/src/Connector.AzureAIStudio/AzureAIStudioConnectorComponent.cs
@@ -1,12 +1,8 @@
-using System.Threading.Tasks;
-
-using CluedIn.Connector.DataLake.Common;
 using CluedIn.Connector.AzureAIStudio.Connector;
+using CluedIn.Connector.DataLake.Common;
 using CluedIn.Core;
 
 using ComponentHost;
-
-using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.AzureAIStudio;
 
@@ -23,26 +19,10 @@ public sealed class AzureAIStudioConnectorComponent : DataLakeConnectorComponent
     /// <summary>Starts this instance.</summary>
     public override void Start()
     {
-        var dataLakeConstants = Container.Resolve<IAzureAIStudioConstants>();
-        var jobDataFactory = Container.Resolve<AzureAIStudioJobDataFactory>();
-        var exportEntitiesJobType = typeof(AzureAIStudioExportEntitiesJob);
-        SubscribeToEvents(dataLakeConstants, exportEntitiesJobType);
-        _ = Task.Run(() => RunScheduler(dataLakeConstants, jobDataFactory, exportEntitiesJobType));
-
-        Log.LogInformation($"{ComponentName} Registered");
-        State = ServiceState.Started;
-    }
-
-    /// <summary>Stops this instance.</summary>
-    public override void Stop()
-    {
-        if (State == ServiceState.Stopped)
-        {
-            return;
-        }
-
-        State = ServiceState.Stopped;
+        DefaultStartInternal<IAzureAIStudioConstants, AzureAIStudioJobDataFactory, AzureAIStudioExportEntitiesJob>();
     }
 
     public const string ComponentName = "Azure AI Studio";
+
+    protected override string ConnectorComponentName => ComponentName;
 }

--- a/src/Connector.AzureDataLake/AzureDataLakeConnectorComponent.cs
+++ b/src/Connector.AzureDataLake/AzureDataLakeConnectorComponent.cs
@@ -1,20 +1,11 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-
 using CluedIn.Connector.AzureDataLake.Connector;
 using CluedIn.Connector.DataLake.Common;
 using CluedIn.Core;
-using CluedIn.Core.Accounts;
-using CluedIn.Core.Data.Relational;
 using CluedIn.Core.DataStore.Entities;
-using CluedIn.Core.Streams;
-using CluedIn.Core.Streams.Models;
 
 using ComponentHost;
 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.AzureDataLake
 {
@@ -33,105 +24,15 @@ namespace CluedIn.Connector.AzureDataLake
             DefaultStartInternal<IAzureDataLakeConstants, AzureDataLakeJobDataFactory, AzureDataLakeExportEntitiesJob>();
         }
 
-        protected override async Task RunMigrations(IDataLakeConstants constants)
+        private protected override IDataMigrator GetDataMigrator(IDataLakeConstants constants, IDataLakeJobDataFactory jobDataFactory)
         {
-            await MigrateMode(constants);
-            await base.RunMigrations(constants);
-        }
-
-        private async Task MigrateMode(IDataLakeConstants dataLakeConstants)
-        {
-            // Set existing streams to EventMode
-            try
-            {
-                var upgradeSettingKey = "ADl Mode Migration";
-
-                var dbContext = new CluedInEntities(Container.Resolve<DbContextOptions<CluedInEntities>>());
-                var modeMigrationSetting = dbContext.Settings.FirstOrDefault(s =>
-                    s.OrganizationId == Guid.Empty && s.Key == upgradeSettingKey);
-                if (modeMigrationSetting != null)
-                {
-                    return;
-                }
-
-                var startedAt = DateTime.Now;
-
-                IStreamRepository streamRepository = null;
-                while (streamRepository == null)
-                {
-                    if (DateTime.Now.Subtract(startedAt).TotalMinutes > 10)
-                    {
-                        Log.LogWarning($"Timeout resolving {nameof(IStreamRepository)}");
-                        return;
-                    }
-
-                    try
-                    {
-                        streamRepository = Container.Resolve<IStreamRepository>();
-                    }
-                    catch
-                    {
-                        await Task.Delay(1000);
-                    }
-                }
-
-                var streams = streamRepository.GetAllStreams().ToList();
-
-                var organizationIds = streams.Select(s => s.OrganizationId).Distinct().ToArray();
-
-                foreach (var orgId in organizationIds)
-                {
-                    var org = new Organization(ApplicationContext, orgId);
-
-                    foreach (var provider in org.Providers.AllProviderDefinitions.Where(x =>
-                                 x.ProviderId == dataLakeConstants.ProviderId))
-                    {
-                        foreach (var stream in streams.Where(s => s.ConnectorProviderDefinitionId == provider.Id))
-                        {
-                            if (stream.Mode != StreamMode.EventStream)
-                            {
-                                var executionContext = ApplicationContext.CreateExecutionContext(orgId);
-
-                                var model = new SetupConnectorModel
-                                {
-                                    ConnectorProviderDefinitionId = provider.Id,
-                                    Mode = StreamMode.EventStream,
-                                    ContainerName = stream.ContainerName,
-                                    DataTypes =
-                                        (await streamRepository.GetStreamMappings(stream.Id))
-                                        .Select(x => new DataTypeEntry
-                                        {
-                                            Key = x.SourceDataType,
-                                            Type = x.SourceObjectType
-                                        }).ToList(),
-                                    ExistingContainerAction = ExistingContainerActionEnum.Archive,
-                                    ExportIncomingEdges = stream.ExportIncomingEdges,
-                                    ExportOutgoingEdges = stream.ExportOutgoingEdges,
-                                    OldContainerName = stream.ContainerName,
-                                };
-
-                                Log.LogInformation($"Setting {nameof(StreamMode.EventStream)} for stream '{{StreamName}}' ({{StreamId}})", stream.Name, stream.Id);
-
-                                await streamRepository.SetupConnector(stream.Id, model, executionContext);
-                            }
-                        }
-                    }
-                }
-
-                dbContext.Settings.Add(new Setting
-                {
-                    Id = Guid.NewGuid(),
-                    OrganizationId = Guid.Empty,
-                    UserId = Guid.Empty,
-                    Key = upgradeSettingKey,
-                    Data = "Complete",
-                });
-                await dbContext.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-                Log.LogError(ex, $"{ComponentName}: Upgrade error");
-            }
+            return new AzureDataLakeDataMigrator(
+                Log,
+                ApplicationContext,
+                Container.Resolve<DbContextOptions<CluedInEntities>>(),
+                ConnectorComponentName,
+                constants,
+                jobDataFactory);
         }
 
         public const string ComponentName = "Azure Data Lake Storage Gen2";

--- a/src/Connector.AzureDataLake/AzureDataLakeConnectorComponent.cs
+++ b/src/Connector.AzureDataLake/AzureDataLakeConnectorComponent.cs
@@ -23,134 +23,119 @@ namespace CluedIn.Connector.AzureDataLake
         Components.Server, Components.DataStores, Isolation = ComponentIsolation.NotIsolated)]
     public sealed class AzureDataLakeConnectorComponent : DataLakeConnectorComponentBase
     {
-
         public AzureDataLakeConnectorComponent(ComponentInfo componentInfo) : base(componentInfo)
         {
             Container.Install(new InstallComponents());
         }
 
-        /// <summary>Starts this instance.</summary>
         public override void Start()
         {
-            var dataLakeConstants = Container.Resolve<IAzureDataLakeConstants>();
-            var jobDataFactory = Container.Resolve<AzureDataLakeJobDataFactory>();
+            DefaultStartInternal<IAzureDataLakeConstants, AzureDataLakeJobDataFactory, AzureDataLakeExportEntitiesJob>();
+        }
 
-            #region Set existing streams to EventMode
-            Task.Run(async () =>
+        protected override async Task RunMigrations(IDataLakeConstants constants)
+        {
+            await MigrateMode(constants);
+            await base.RunMigrations(constants);
+        }
+
+        private async Task MigrateMode(IDataLakeConstants dataLakeConstants)
+        {
+            // Set existing streams to EventMode
+            try
             {
-                try
-                {
-                    var upgradeSettingKey = "ADl Mode Migration";
+                var upgradeSettingKey = "ADl Mode Migration";
 
-                    var dbContext = new CluedInEntities(Container.Resolve<DbContextOptions<CluedInEntities>>());
-                    var modeMigrationSetting = dbContext.Settings.FirstOrDefault(s =>
-                        s.OrganizationId == Guid.Empty && s.Key == upgradeSettingKey);
-                    if (modeMigrationSetting != null)
+                var dbContext = new CluedInEntities(Container.Resolve<DbContextOptions<CluedInEntities>>());
+                var modeMigrationSetting = dbContext.Settings.FirstOrDefault(s =>
+                    s.OrganizationId == Guid.Empty && s.Key == upgradeSettingKey);
+                if (modeMigrationSetting != null)
+                {
+                    return;
+                }
+
+                var startedAt = DateTime.Now;
+
+                IStreamRepository streamRepository = null;
+                while (streamRepository == null)
+                {
+                    if (DateTime.Now.Subtract(startedAt).TotalMinutes > 10)
                     {
+                        Log.LogWarning($"Timeout resolving {nameof(IStreamRepository)}");
                         return;
                     }
 
-                    var startedAt = DateTime.Now;
-
-                    IStreamRepository streamRepository = null;
-                    while (streamRepository == null)
+                    try
                     {
-                        if (DateTime.Now.Subtract(startedAt).TotalMinutes > 10)
-                        {
-                            Log.LogWarning($"Timeout resolving {nameof(IStreamRepository)}");
-                            return;
-                        }
-
-                        try
-                        {
-                            streamRepository = Container.Resolve<IStreamRepository>();
-                        }
-                        catch
-                        {
-                            await Task.Delay(1000);
-                        }
+                        streamRepository = Container.Resolve<IStreamRepository>();
                     }
-
-                    var streams = streamRepository.GetAllStreams().ToList();
-
-                    var organizationIds = streams.Select(s => s.OrganizationId).Distinct().ToArray();
-
-                    foreach (var orgId in organizationIds)
+                    catch
                     {
-                        var org = new Organization(ApplicationContext, orgId);
+                        await Task.Delay(1000);
+                    }
+                }
 
-                        foreach (var provider in org.Providers.AllProviderDefinitions.Where(x =>
-                                     x.ProviderId == dataLakeConstants.ProviderId))
+                var streams = streamRepository.GetAllStreams().ToList();
+
+                var organizationIds = streams.Select(s => s.OrganizationId).Distinct().ToArray();
+
+                foreach (var orgId in organizationIds)
+                {
+                    var org = new Organization(ApplicationContext, orgId);
+
+                    foreach (var provider in org.Providers.AllProviderDefinitions.Where(x =>
+                                 x.ProviderId == dataLakeConstants.ProviderId))
+                    {
+                        foreach (var stream in streams.Where(s => s.ConnectorProviderDefinitionId == provider.Id))
                         {
-                            foreach (var stream in streams.Where(s => s.ConnectorProviderDefinitionId == provider.Id))
+                            if (stream.Mode != StreamMode.EventStream)
                             {
-                                if (stream.Mode != StreamMode.EventStream)
+                                var executionContext = ApplicationContext.CreateExecutionContext(orgId);
+
+                                var model = new SetupConnectorModel
                                 {
-                                    var executionContext = ApplicationContext.CreateExecutionContext(orgId);
+                                    ConnectorProviderDefinitionId = provider.Id,
+                                    Mode = StreamMode.EventStream,
+                                    ContainerName = stream.ContainerName,
+                                    DataTypes =
+                                        (await streamRepository.GetStreamMappings(stream.Id))
+                                        .Select(x => new DataTypeEntry
+                                        {
+                                            Key = x.SourceDataType,
+                                            Type = x.SourceObjectType
+                                        }).ToList(),
+                                    ExistingContainerAction = ExistingContainerActionEnum.Archive,
+                                    ExportIncomingEdges = stream.ExportIncomingEdges,
+                                    ExportOutgoingEdges = stream.ExportOutgoingEdges,
+                                    OldContainerName = stream.ContainerName,
+                                };
 
-                                    var model = new SetupConnectorModel
-                                    {
-                                        ConnectorProviderDefinitionId = provider.Id,
-                                        Mode = StreamMode.EventStream,
-                                        ContainerName = stream.ContainerName,
-                                        DataTypes =
-                                            (await streamRepository.GetStreamMappings(stream.Id))
-                                            .Select(x => new DataTypeEntry
-                                            {
-                                                Key = x.SourceDataType,
-                                                Type = x.SourceObjectType
-                                            }).ToList(),
-                                        ExistingContainerAction = ExistingContainerActionEnum.Archive,
-                                        ExportIncomingEdges = stream.ExportIncomingEdges,
-                                        ExportOutgoingEdges = stream.ExportOutgoingEdges,
-                                        OldContainerName = stream.ContainerName,
-                                    };
+                                Log.LogInformation($"Setting {nameof(StreamMode.EventStream)} for stream '{{StreamName}}' ({{StreamId}})", stream.Name, stream.Id);
 
-                                    Log.LogInformation($"Setting {nameof(StreamMode.EventStream)} for stream '{{StreamName}}' ({{StreamId}})", stream.Name, stream.Id);
-
-                                    await streamRepository.SetupConnector(stream.Id, model, executionContext);
-                                }
+                                await streamRepository.SetupConnector(stream.Id, model, executionContext);
                             }
                         }
                     }
-
-                    dbContext.Settings.Add(new Setting
-                    {
-                        Id = Guid.NewGuid(),
-                        OrganizationId = Guid.Empty,
-                        UserId = Guid.Empty,
-                        Key = upgradeSettingKey,
-                        Data = "Complete",
-                    });
-                    await dbContext.SaveChangesAsync();
                 }
-                catch (Exception ex)
+
+                dbContext.Settings.Add(new Setting
                 {
-                    Log.LogError(ex, $"{ComponentName}: Upgrade error");
-                }
-            });
-            #endregion
-
-            var exportEntitiesJobType = typeof(AzureDataLakeExportEntitiesJob);
-            SubscribeToEvents(dataLakeConstants, exportEntitiesJobType);
-            _ = Task.Run(() => RunScheduler(dataLakeConstants, jobDataFactory, exportEntitiesJobType));
-
-            Log.LogInformation($"{ComponentName} Registered");
-            State = ServiceState.Started;
-        }
-
-        /// <summary>Stops this instance.</summary>
-        public override void Stop()
-        {
-            if (State == ServiceState.Stopped)
-            {
-                return;
+                    Id = Guid.NewGuid(),
+                    OrganizationId = Guid.Empty,
+                    UserId = Guid.Empty,
+                    Key = upgradeSettingKey,
+                    Data = "Complete",
+                });
+                await dbContext.SaveChangesAsync();
             }
-
-            State = ServiceState.Stopped;
+            catch (Exception ex)
+            {
+                Log.LogError(ex, $"{ComponentName}: Upgrade error");
+            }
         }
-
 
         public const string ComponentName = "Azure Data Lake Storage Gen2";
+
+        protected override string ConnectorComponentName => ComponentName;
     }
 }

--- a/src/Connector.AzureDataLake/AzureDataLakeDataMigrator.cs
+++ b/src/Connector.AzureDataLake/AzureDataLakeDataMigrator.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+
+using Castle.Core;
+
+using CluedIn.Connector.DataLake.Common;
+using CluedIn.Core;
+using CluedIn.Core.Accounts;
+using CluedIn.Core.Data.Relational;
+using CluedIn.Core.DataStore.Entities;
+using CluedIn.Core.Streams;
+using CluedIn.Core.Streams.Models;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace CluedIn.Connector.AzureDataLake;
+
+internal class AzureDataLakeDataMigrator : DataLakeDataMigrator
+{
+    public AzureDataLakeDataMigrator(
+        ILogger logger,
+        ApplicationContext applicationContext,
+        DbContextOptions<CluedInEntities> cluedInEntitiesDbContextOptions,
+        string componentName,
+        IDataLakeConstants constants,
+        IDataLakeJobDataFactory dataLakeJobDataFactory) : base(logger, applicationContext, cluedInEntitiesDbContextOptions, componentName, constants, dataLakeJobDataFactory)
+    {
+    }
+
+    protected override async Task RunMigrations()
+    {
+        await MigrateMode();
+        await base.RunMigrations();
+    }
+
+    private async Task MigrateMode()
+    {
+        // Set existing streams to EventMode
+        try
+        {
+            var upgradeSettingKey = "ADl Mode Migration";
+
+            var dbContext = new CluedInEntities(_applicationContext.Container.Resolve<DbContextOptions<CluedInEntities>>());
+            var modeMigrationSetting = dbContext.Settings.FirstOrDefault(s =>
+                s.OrganizationId == Guid.Empty && s.Key == upgradeSettingKey);
+            if (modeMigrationSetting != null)
+            {
+                return;
+            }
+
+            var startedAt = DateTime.Now;
+
+            IStreamRepository streamRepository = null;
+            while (streamRepository == null)
+            {
+                if (DateTime.Now.Subtract(startedAt).TotalMinutes > 10)
+                {
+                    _logger.LogWarning($"Timeout resolving {nameof(IStreamRepository)}");
+                    return;
+                }
+
+                try
+                {
+                    streamRepository = _applicationContext.Container.Resolve<IStreamRepository>();
+                }
+                catch
+                {
+                    await Task.Delay(1000);
+                }
+            }
+
+            var streams = streamRepository.GetAllStreams().ToList();
+
+            var organizationIds = streams.Select(s => s.OrganizationId).Distinct().ToArray();
+
+            foreach (var orgId in organizationIds)
+            {
+                var org = new Organization(_applicationContext, orgId);
+
+                foreach (var provider in org.Providers.AllProviderDefinitions.Where(x =>
+                             x.ProviderId == _dataLakeConstants.ProviderId))
+                {
+                    foreach (var stream in streams.Where(s => s.ConnectorProviderDefinitionId == provider.Id))
+                    {
+                        if (stream.Mode != StreamMode.EventStream)
+                        {
+                            var executionContext = _applicationContext.CreateExecutionContext(orgId);
+
+                            var model = new SetupConnectorModel
+                            {
+                                ConnectorProviderDefinitionId = provider.Id,
+                                Mode = StreamMode.EventStream,
+                                ContainerName = stream.ContainerName,
+                                DataTypes =
+                                    (await streamRepository.GetStreamMappings(stream.Id))
+                                    .Select(x => new DataTypeEntry
+                                    {
+                                        Key = x.SourceDataType,
+                                        Type = x.SourceObjectType
+                                    }).ToList(),
+                                ExistingContainerAction = ExistingContainerActionEnum.Archive,
+                                ExportIncomingEdges = stream.ExportIncomingEdges,
+                                ExportOutgoingEdges = stream.ExportOutgoingEdges,
+                                OldContainerName = stream.ContainerName,
+                            };
+
+                            _logger.LogInformation($"Setting {nameof(StreamMode.EventStream)} for stream '{{StreamName}}' ({{StreamId}})", stream.Name, stream.Id);
+
+                            await streamRepository.SetupConnector(stream.Id, model, executionContext);
+                        }
+                    }
+                }
+            }
+
+            dbContext.Settings.Add(new Setting
+            {
+                Id = Guid.NewGuid(),
+                OrganizationId = Guid.Empty,
+                UserId = Guid.Empty,
+                Key = upgradeSettingKey,
+                Data = "Complete",
+            });
+            await dbContext.SaveChangesAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"{_componentName}: Upgrade error");
+        }
+    }
+}

--- a/src/Connector.AzureDatabricks/AzureDatabricksConnectorComponent.cs
+++ b/src/Connector.AzureDatabricks/AzureDatabricksConnectorComponent.cs
@@ -1,20 +1,8 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-using CluedIn.Connector.AzureDatabricks;
 using CluedIn.Connector.AzureDatabricks.Connector;
 using CluedIn.Connector.DataLake.Common;
 using CluedIn.Core;
-using CluedIn.Core.Accounts;
-using CluedIn.Core.Data.Relational;
-using CluedIn.Core.DataStore.Entities;
-using CluedIn.Core.Streams;
-using CluedIn.Core.Streams.Models;
 
 using ComponentHost;
-
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.AzureDatabricks
 {
@@ -32,125 +20,11 @@ namespace CluedIn.Connector.AzureDatabricks
         /// <summary>Starts this instance.</summary>
         public override void Start()
         {
-            var databricksConstants = Container.Resolve<IAzureDatabricksConstants>();
-            var jobDataFactory = Container.Resolve<AzureDatabricksJobDataFactory>();
-
-            #region Set existing streams to EventMode
-            Task.Run(async () =>
-            {
-                try
-                {
-                    var upgradeSettingKey = "ADl Mode Migration";
-
-                    var dbContext = new CluedInEntities(Container.Resolve<DbContextOptions<CluedInEntities>>());
-                    var modeMigrationSetting = dbContext.Settings.FirstOrDefault(s =>
-                        s.OrganizationId == Guid.Empty && s.Key == upgradeSettingKey);
-                    if (modeMigrationSetting != null)
-                    {
-                        return;
-                    }
-
-                    var startedAt = DateTime.Now;
-
-                    IStreamRepository streamRepository = null;
-                    while (streamRepository == null)
-                    {
-                        if (DateTime.Now.Subtract(startedAt).TotalMinutes > 10)
-                        {
-                            Log.LogWarning($"Timeout resolving {nameof(IStreamRepository)}");
-                            return;
-                        }
-
-                        try
-                        {
-                            streamRepository = Container.Resolve<IStreamRepository>();
-                        }
-                        catch
-                        {
-                            await Task.Delay(1000);
-                        }
-                    }
-
-                    var streams = streamRepository.GetAllStreams().ToList();
-
-                    var organizationIds = streams.Select(s => s.OrganizationId).Distinct().ToArray();
-
-                    foreach (var orgId in organizationIds)
-                    {
-                        var org = new Organization(ApplicationContext, orgId);
-
-                        foreach (var provider in org.Providers.AllProviderDefinitions.Where(x =>
-                                     x.ProviderId == databricksConstants.ProviderId))
-                        {
-                            foreach (var stream in streams.Where(s => s.ConnectorProviderDefinitionId == provider.Id))
-                            {
-                                if (stream.Mode != StreamMode.EventStream)
-                                {
-                                    var executionContext = ApplicationContext.CreateExecutionContext(orgId);
-
-                                    var model = new SetupConnectorModel
-                                    {
-                                        ConnectorProviderDefinitionId = provider.Id,
-                                        Mode = StreamMode.EventStream,
-                                        ContainerName = stream.ContainerName,
-                                        DataTypes =
-                                            (await streamRepository.GetStreamMappings(stream.Id))
-                                            .Select(x => new DataTypeEntry
-                                            {
-                                                Key = x.SourceDataType,
-                                                Type = x.SourceObjectType
-                                            }).ToList(),
-                                        ExistingContainerAction = ExistingContainerActionEnum.Archive,
-                                        ExportIncomingEdges = stream.ExportIncomingEdges,
-                                        ExportOutgoingEdges = stream.ExportOutgoingEdges,
-                                        OldContainerName = stream.ContainerName,
-                                    };
-
-                                    Log.LogInformation($"Setting {nameof(StreamMode.EventStream)} for stream '{{StreamName}}' ({{StreamId}})", stream.Name, stream.Id);
-
-                                    await streamRepository.SetupConnector(stream.Id, model, executionContext);
-                                }
-                            }
-                        }
-                    }
-
-                    dbContext.Settings.Add(new Setting
-                    {
-                        Id = Guid.NewGuid(),
-                        OrganizationId = Guid.Empty,
-                        UserId = Guid.Empty,
-                        Key = upgradeSettingKey,
-                        Data = "Complete",
-                    });
-                    await dbContext.SaveChangesAsync();
-                }
-                catch (Exception ex)
-                {
-                    Log.LogError(ex, $"{ComponentName}: Upgrade error");
-                }
-            });
-            #endregion
-
-            var exportEntitiesJobType = typeof(AzureDatabricksExportEntitiesJob);
-            SubscribeToEvents(databricksConstants, exportEntitiesJobType);
-            _ = Task.Run(() => RunScheduler(databricksConstants, jobDataFactory, exportEntitiesJobType));
-
-            Log.LogInformation($"{ComponentName} Registered");
-            State = ServiceState.Started;
+            DefaultStartInternal<IAzureDatabricksConstants, AzureDatabricksJobDataFactory, AzureDatabricksExportEntitiesJob>();
         }
-
-        /// <summary>Stops this instance.</summary>
-        public override void Stop()
-        {
-            if (State == ServiceState.Stopped)
-            {
-                return;
-            }
-
-            State = ServiceState.Stopped;
-        }
-
 
         public const string ComponentName = "Azure Databricks";
+
+        protected override string ConnectorComponentName => ComponentName;
     }
 }

--- a/src/Connector.DataLake.Common/AccountIdHelper.cs
+++ b/src/Connector.DataLake.Common/AccountIdHelper.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 
-namespace CluedIn.Connector.DataLake.Common
+namespace CluedIn.Connector.DataLake.Common;
+
+internal class AccountIdHelper
 {
-    internal class AccountIdHelper
+    public static string Generate(Guid providerId, Guid providerDefinitionId)
     {
-        public static string Generate(Guid providerId, Guid providerDefinitionId)
-        {
-            return $"{providerId}_{providerDefinitionId}";
-        }
+        return $"{providerId}_{providerDefinitionId}";
     }
 }

--- a/src/Connector.DataLake.Common/AccountIdHelper.cs
+++ b/src/Connector.DataLake.Common/AccountIdHelper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace CluedIn.Connector.DataLake.Common
+{
+    internal class AccountIdHelper
+    {
+        public static string Generate(Guid providerId, Guid providerDefinitionId)
+        {
+            return $"{providerId}_{providerDefinitionId}";
+        }
+    }
+}

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -260,7 +260,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         private Task<bool> TryAcquireTableCreationLock(SqlConnection connection, string tableName)
         {
             var typeName = this.GetType().Name;
-            return DistributedLockHelper.TryAcquireTableCreationLock(
+            return DistributedLockHelper.TryAcquireExclusiveLock(
                 connection,
                 $"{typeName}_{tableName}",
                 TableCreationLockTimeoutInMillliseconds);
@@ -495,7 +495,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 await using var connection = new SqlConnection(connectionString);
                 await connection.OpenAsync();
 
-                if (!await DistributedLockHelper.TryAcquireTableCreationLock(connection, nameof(VerifyConnection), -1))
+                if (!await DistributedLockHelper.TryAcquireExclusiveLock(connection, nameof(VerifyConnection), -1))
                 {
                     throw new ApplicationException("Failed to acquire lock for verifying connection.");
                 }

--- a/src/Connector.DataLake.Common/ConnectorProviderBase.cs
+++ b/src/Connector.DataLake.Common/ConnectorProviderBase.cs
@@ -82,7 +82,8 @@ namespace CluedIn.Connector.DataLake.Common
                 }
             }
 
-            return Task.FromResult(new AccountInformation(string.Empty, displayNameBuilder.ToString()));
+            var accountId = AccountIdHelper.Generate(_configurationConstants.ProviderId, providerDefinitionId);
+            return Task.FromResult(new AccountInformation(accountId, displayNameBuilder.ToString()));
         }
 
         /// <summary>

--- a/src/Connector.DataLake.Common/DataLakeConnectorComponentBase.cs
+++ b/src/Connector.DataLake.Common/DataLakeConnectorComponentBase.cs
@@ -27,7 +27,7 @@ public abstract class DataLakeConnectorComponentBase : ServiceApplicationCompone
 
     private static readonly NCrontab.CrontabSchedule _schedulerCron = NCrontab.CrontabSchedule.Parse("* * * * *");
     private static readonly TimeSpan _initialSchedulerDelay = TimeSpan.FromSeconds(3);
-    private static readonly TimeSpan _schedulerErrorDelay = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan _delayAfterError = TimeSpan.FromMinutes(1);
 
     protected DataLakeConnectorComponentBase(ComponentInfo componentInfo) : base(componentInfo)
     {
@@ -102,8 +102,8 @@ public abstract class DataLakeConnectorComponentBase : ServiceApplicationCompone
             }
             catch(Exception ex)
             {
-                Log.LogError(ex, "Error occurred when scheduling. Waiting {DelayAfterError} before next schedule run.", _schedulerErrorDelay);
-                await Task.Delay(_schedulerErrorDelay);
+                Log.LogError(ex, "Error occurred when scheduling. Waiting {DelayAfterError} before next schedule run.", _delayAfterError);
+                await Task.Delay(_delayAfterError);
             }
         }
     }

--- a/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using CluedIn.Core;
+using CluedIn.Core.Data.Relational;
+using CluedIn.Core.DataStore.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace CluedIn.Connector.DataLake.Common;
+
+internal class DataLakeDataMigrator : DataMigrator
+{
+    protected readonly IDataLakeConstants _dataLakeConstants;
+    protected readonly IDataLakeJobDataFactory _dataLakeJobDataFactory;
+
+    public DataLakeDataMigrator(
+        ILogger logger,
+        ApplicationContext applicationContext,
+        DbContextOptions<CluedInEntities> cluedInEntitiesDbContextOptions,
+        string componentName,
+        IDataLakeConstants constants,
+        IDataLakeJobDataFactory dataLakeJobDataFactory) : base (logger, applicationContext, cluedInEntitiesDbContextOptions, componentName)
+    {
+        _dataLakeConstants = constants ?? throw new ArgumentNullException(nameof(constants));
+        _dataLakeJobDataFactory = dataLakeJobDataFactory ?? throw new ArgumentNullException(nameof(dataLakeJobDataFactory));
+    }
+
+    protected override async Task RunMigrations()
+    {
+        await MigrateAccountId();
+    }
+
+    protected virtual async Task MigrateAccountId()
+    {
+        await MigrateForOrganizations("EmptyAccountId", migrateAccountIdForProviderDefinition);
+        async Task migrateAccountIdForProviderDefinition(ExecutionContext context, string componentMigrationName)
+        {
+            var organizationId = context.Organization.Id;
+            var store = context.Organization.DataStores.GetDataStore<ProviderDefinition>();
+            var definitions = await store.SelectAsync(
+                context,
+                definition => definition.OrganizationId == context.Organization.Id
+                                && definition.ProviderId == _dataLakeConstants.ProviderId);
+            foreach (var definition in definitions)
+            {
+                if (definition.AccountId != string.Empty)
+                {
+                    _logger.LogDebug("Skipping provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
+                        componentMigrationName,
+                        organizationId,
+                        definition.Id);
+                    continue;
+                }
+
+                _logger.LogInformation("Begin provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
+                    componentMigrationName,
+                    organizationId,
+                    definition.Id);
+                definition.AccountId = AccountIdHelper.Generate(_dataLakeConstants.ProviderId, definition.Id);
+                await store.UpdateAsync(context, definition);
+                _logger.LogInformation("End provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
+                    componentMigrationName,
+                    organizationId,
+                    definition.Id);
+            }
+        }
+    }
+}

--- a/src/Connector.DataLake.Common/DataLakeJobArgs.cs
+++ b/src/Connector.DataLake.Common/DataLakeJobArgs.cs
@@ -2,7 +2,7 @@
 
 namespace CluedIn.Connector.DataLake.Common;
 
-internal class DataLakeJobArgs : JobArgs
+internal class DataLakeJobArgs : JobArgs, IDataLakeJobArgs
 {
     public DataLakeJobArgs() : base()
     {

--- a/src/Connector.DataLake.Common/DataLakeJobBase.cs
+++ b/src/Connector.DataLake.Common/DataLakeJobBase.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace CluedIn.Connector.DataLake.Common;
 
-internal abstract class DataLakeJobBase : JobBase, ICustomScheduledJob
+internal abstract class DataLakeJobBase : JobBase, ICustomScheduledJob, IDataLakeJob
 {
     protected DataLakeJobBase(ApplicationContext appContext) : base(appContext, JobType.CustomScheduledJob)
     {
@@ -21,7 +21,7 @@ internal abstract class DataLakeJobBase : JobBase, ICustomScheduledJob
         DoRunAsync(context, new DataLakeJobArgs(args, isTriggeredFromJobServer: true)).GetAwaiter().GetResult();
     }
 
-    public abstract Task DoRunAsync(ExecutionContext context, DataLakeJobArgs args);
+    public abstract Task DoRunAsync(ExecutionContext context, IDataLakeJobArgs args);
 
     /// <summary>
     /// Register and schedule current job for recurrent run.

--- a/src/Connector.DataLake.Common/DataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataMigrator.cs
@@ -155,7 +155,7 @@ internal class DataMigrator : IDataMigrator
 
     public async Task<bool> IsMigrationPerformedAsync(Guid organizationId, string key)
     {
-        var dbContext = new CluedInEntities();
+        var dbContext = new CluedInEntities(_cluedInEntitiesDbContextOptions);
         var migrationSetting = await dbContext.Settings
                 .FirstOrDefaultAsync(setting => setting.OrganizationId == Guid.Empty
                                 && setting.Key == key);
@@ -165,7 +165,7 @@ internal class DataMigrator : IDataMigrator
 
     public async Task SetMigrationPerformedAsync(Guid organizationId, string key)
     {
-        var dbContext = new CluedInEntities();
+        var dbContext = new CluedInEntities(_cluedInEntitiesDbContextOptions);
         dbContext.Settings.Add(new Setting
         {
             Id = Guid.NewGuid(),

--- a/src/Connector.DataLake.Common/DataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataMigrator.cs
@@ -182,7 +182,7 @@ internal class DataMigrator : IDataMigrator
         string migrationName,
         Func<string, Task> migrateTask)
     {
-        var componentMigrationName = $"{_componentName}:{migrationName}";
+        var componentMigrationName = $"{_componentName}:Migration:{migrationName}";
         try
         {
             var hasMigrationPerformed = await IsMigrationPerformedAsync(Guid.Empty, componentMigrationName);

--- a/src/Connector.DataLake.Common/DataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataMigrator.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using CluedIn.Connector.DataLake.Common.Connector;
+using CluedIn.Core;
+using CluedIn.Core.Accounts;
+using CluedIn.Core.Data.Relational;
+using CluedIn.Core.DataStore.Entities;
+
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace CluedIn.Connector.DataLake.Common;
+
+internal class DataMigrator : IDataMigrator
+{
+    private const string MigrationLockConnectionString = "Locking";
+    private static readonly TimeSpan _migrationRetryDelay = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan _migrationLockTimeout = TimeSpan.FromMilliseconds(10);
+    private static readonly TimeSpan _migrationRetryTimeout = TimeSpan.FromMinutes(10);
+    private static readonly int _migrationMaxRetries = 3;
+
+    protected string _componentName;
+    protected ILogger _logger;
+    protected ApplicationContext _applicationContext;
+
+    private DbContextOptions<CluedInEntities> _cluedInEntitiesDbContextOptions;
+
+    public DataMigrator(
+        ILogger logger,
+        ApplicationContext applicationContext,
+        DbContextOptions<CluedInEntities> cluedInEntitiesDbContextOptions,
+        string componentName)
+    {
+        if (string.IsNullOrEmpty(componentName))
+        {
+            throw new ArgumentException($"'{nameof(componentName)}' cannot be null or empty.", nameof(componentName));
+        }
+
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
+        _cluedInEntitiesDbContextOptions = cluedInEntitiesDbContextOptions ?? throw new ArgumentNullException(nameof(cluedInEntitiesDbContextOptions));
+        _componentName = componentName;
+    }
+
+    public async Task MigrateAsync()
+    {
+        await RunMigrationsWithLock();
+    }
+
+    protected virtual async Task RunMigrationsWithLock()
+    {
+        var migrationErrorCount = 0;
+        var migrationStart = DateTimeOffset.UtcNow;
+        var shouldRetry = true;
+
+        if (!_applicationContext.System.ConnectionStrings.ConnectionStringExists(MigrationLockConnectionString))
+        {
+            throw new InvalidOperationException($"Connection string {MigrationLockConnectionString} is not found.");
+        }
+
+        var connectionString = _applicationContext.System.ConnectionStrings.GetConnectionString(MigrationLockConnectionString);
+        while (true)
+        {
+            try
+            {
+                using var connection = new SqlConnection(connectionString);
+                await connection.OpenAsync();
+                var transaction = connection.BeginTransaction();
+                _logger.LogDebug("Try to acquire lock for '{ConnectorComponentName}' migration.", _componentName);
+                var hasAcquiredLock = await DistributedLockHelper.TryAcquireExclusiveLock(
+                    transaction,
+                    $"{_componentName}-Migration",
+                    (int)_migrationLockTimeout.TotalMilliseconds);
+                if (hasAcquiredLock)
+                {
+                    _logger.LogDebug("Acquired lock for '{ConnectorComponentName}' migration.", _componentName);
+                    await tryRunMigrations();
+                    if (!shouldRetry)
+                    {
+                        return;
+                    }
+                }
+                else
+                {
+                    _logger.LogDebug("Failed to acquire lock for '{ConnectorComponentName}' migration.", _componentName);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error occurred while trying to acquire lock for '{ConnectorComponentName}' migration.", _componentName);
+            }
+
+            var elapsed = DateTimeOffset.UtcNow - migrationStart;
+            if (elapsed > _migrationRetryTimeout)
+            {
+                _logger.LogError("Timeout while trying to perform '{ConnectorComponentName}' migration.", _componentName);
+                return;
+            }
+
+            _logger.LogDebug("Retry '{ConnectorComponentName}' migration in {DelayBetweenMigrationRetries}.", _componentName, _migrationRetryDelay);
+            await Task.Delay(_migrationRetryDelay);
+        }
+
+        async Task tryRunMigrations()
+        {
+            try
+            {
+                _logger.LogDebug("Begin '{ConnectorComponentName}' migration.", _componentName);
+                await RunMigrations();
+                _logger.LogDebug("End '{ConnectorComponentName}' migration.", _componentName);
+                shouldRetry = false;
+            }
+            catch (Exception ex)
+            {
+                migrationErrorCount++;
+
+                if (migrationErrorCount > _migrationMaxRetries)
+                {
+                    _logger.LogWarning(ex, "Failed to perform '{ConnectorComponentName}' migration after {TotalAttempts} attempts. Giving up.", _componentName, migrationErrorCount);
+                    shouldRetry = false;
+                }
+
+                _logger.LogWarning(ex, "Error occurred while trying to perform '{ConnectorComponentName}' migration.", _componentName);
+            }
+        }
+    }
+
+    protected virtual Task RunMigrations()
+    {
+        return Task.CompletedTask;
+    }
+
+    protected async Task MigrateForOrganizations(
+        string migrationName,
+        Func<ExecutionContext, string, Task> migrateTask)
+    {
+        await Migrate(migrationName, migrateOrganizationTask);
+        async Task migrateOrganizationTask(string migrationName)
+        {
+            var orgDataStore = _applicationContext.System.Organization.DataStores.GetDataStore<OrganizationProfile>();
+            var organizationProfiles = await orgDataStore.SelectAsync(_applicationContext.System.CreateExecutionContext(), _ => true);
+            foreach (var organizationProfile in organizationProfiles)
+            {
+                var organizationId = organizationProfile.Id;
+                _logger.LogInformation("Begin organization migration: '{MigrationName}' for organization '{OrganizationId}'.", migrationName, organizationId);
+                var organization = new Organization(_applicationContext, organizationId);
+                var executionContext = _applicationContext.CreateExecutionContext(organizationId);
+                await migrateTask(executionContext, migrationName);
+                _logger.LogInformation("End organization migration: '{MigrationName}' for organization '{OrganizationId}'.", migrationName, organizationId);
+            }
+        }
+    }
+
+    public async Task<bool> IsMigrationPerformedAsync(Guid organizationId, string key)
+    {
+        var dbContext = new CluedInEntities();
+        var migrationSetting = await dbContext.Settings
+                .FirstOrDefaultAsync(setting => setting.OrganizationId == Guid.Empty
+                                && setting.Key == key);
+
+        return migrationSetting != null;
+    }
+
+    public async Task SetMigrationPerformedAsync(Guid organizationId, string key)
+    {
+        var dbContext = new CluedInEntities();
+        dbContext.Settings.Add(new Setting
+        {
+            Id = Guid.NewGuid(),
+            OrganizationId = Guid.Empty,
+            UserId = Guid.Empty,
+            Key = key,
+            Data = "Complete",
+        });
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    protected async Task Migrate(
+        string migrationName,
+        Func<string, Task> migrateTask)
+    {
+        var componentMigrationName = $"{_componentName}:{migrationName}";
+        try
+        {
+            var hasMigrationPerformed = await IsMigrationPerformedAsync(Guid.Empty, componentMigrationName);
+            if (hasMigrationPerformed)
+            {
+                _logger.LogDebug("Skipping migration: '{MigrationName}' because it has already been performed.", componentMigrationName);
+                return;
+            }
+
+            _logger.LogInformation("Begin migration: '{MigrationName}'.", componentMigrationName);
+
+            await migrateTask(componentMigrationName);
+
+            await SetMigrationPerformedAsync(Guid.Empty, componentMigrationName);
+            _logger.LogInformation("End migration: '{MigrationName}'.", componentMigrationName);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error trying to perform migration: '{MigrationName}'.", componentMigrationName);
+        }
+    }
+}

--- a/src/Connector.DataLake.Common/IDataLakeExportEntitiesJob.cs
+++ b/src/Connector.DataLake.Common/IDataLakeExportEntitiesJob.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+using CluedIn.Core;
+
+namespace CluedIn.Connector.DataLake.Common
+{
+    public interface IDataLakeJob
+    {
+        Task DoRunAsync(ExecutionContext context, IDataLakeJobArgs args);
+    }
+}

--- a/src/Connector.DataLake.Common/IDataLakeExportEntitiesJob.cs
+++ b/src/Connector.DataLake.Common/IDataLakeExportEntitiesJob.cs
@@ -2,10 +2,9 @@
 
 using CluedIn.Core;
 
-namespace CluedIn.Connector.DataLake.Common
+namespace CluedIn.Connector.DataLake.Common;
+
+public interface IDataLakeJob
 {
-    public interface IDataLakeJob
-    {
-        Task DoRunAsync(ExecutionContext context, IDataLakeJobArgs args);
-    }
+    Task DoRunAsync(ExecutionContext context, IDataLakeJobArgs args);
 }

--- a/src/Connector.DataLake.Common/IDataLakeJobArgs.cs
+++ b/src/Connector.DataLake.Common/IDataLakeJobArgs.cs
@@ -1,0 +1,9 @@
+﻿using CluedIn.Core.Jobs;
+
+namespace CluedIn.Connector.DataLake.Common
+{
+    public interface IDataLakeJobArgs : IJobArgs
+    {
+        bool IsTriggeredFromJobServer { get; set; }
+    }
+}

--- a/src/Connector.DataLake.Common/IDataLakeJobArgs.cs
+++ b/src/Connector.DataLake.Common/IDataLakeJobArgs.cs
@@ -1,9 +1,8 @@
 ﻿using CluedIn.Core.Jobs;
 
-namespace CluedIn.Connector.DataLake.Common
+namespace CluedIn.Connector.DataLake.Common;
+
+public interface IDataLakeJobArgs : IJobArgs
 {
-    public interface IDataLakeJobArgs : IJobArgs
-    {
-        bool IsTriggeredFromJobServer { get; set; }
-    }
+    bool IsTriggeredFromJobServer { get; set; }
 }

--- a/src/Connector.DataLake.Common/IDataMigrator.cs
+++ b/src/Connector.DataLake.Common/IDataMigrator.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CluedIn.Connector.DataLake.Common;
+
+internal interface IDataMigrator
+{
+    Task MigrateAsync();
+    Task<bool> IsMigrationPerformedAsync(Guid organizationId, string key);
+    Task SetMigrationPerformedAsync(Guid organizationId, string key);
+}

--- a/src/Connector.OneLake/OneLakeConnectorComponent.cs
+++ b/src/Connector.OneLake/OneLakeConnectorComponent.cs
@@ -1,12 +1,8 @@
-using System.Threading.Tasks;
-
 using CluedIn.Connector.DataLake.Common;
 using CluedIn.Connector.OneLake.Connector;
 using CluedIn.Core;
 
 using ComponentHost;
-
-using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.OneLake;
 
@@ -23,26 +19,10 @@ public sealed class OneLakeConnectorComponent : DataLakeConnectorComponentBase
     /// <summary>Starts this instance.</summary>
     public override void Start()
     {
-        var dataLakeConstants = Container.Resolve<IOneLakeConstants>();
-        var jobDataFactory = Container.Resolve<OneLakeJobDataFactory>();
-        var exportEntitiesJobType = typeof(OneLakeExportEntitiesJob);
-        SubscribeToEvents(dataLakeConstants, exportEntitiesJobType);
-        _ = Task.Run(() => RunScheduler(dataLakeConstants, jobDataFactory, exportEntitiesJobType));
-
-        Log.LogInformation($"{ComponentName} Registered");
-        State = ServiceState.Started;
-    }
-
-    /// <summary>Stops this instance.</summary>
-    public override void Stop()
-    {
-        if (State == ServiceState.Stopped)
-        {
-            return;
-        }
-
-        State = ServiceState.Stopped;
+        DefaultStartInternal<IOneLakeConstants, OneLakeJobDataFactory, OneLakeExportEntitiesJob>();
     }
 
     public const string ComponentName = "OneLake";
+
+    protected override string ConnectorComponentName => ComponentName;
 }

--- a/src/Connector.SynapseDataEngineering/SynapseDataEngineeringConnectorComponent.cs
+++ b/src/Connector.SynapseDataEngineering/SynapseDataEngineeringConnectorComponent.cs
@@ -1,20 +1,8 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
-using CluedIn.Connector.SynapseDataEngineering;
-using CluedIn.Connector.SynapseDataEngineering.Connector;
 using CluedIn.Connector.DataLake.Common;
+using CluedIn.Connector.SynapseDataEngineering.Connector;
 using CluedIn.Core;
-using CluedIn.Core.Accounts;
-using CluedIn.Core.Data.Relational;
-using CluedIn.Core.DataStore.Entities;
-using CluedIn.Core.Streams;
-using CluedIn.Core.Streams.Models;
 
 using ComponentHost;
-
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.SynapseDataEngineering
 {
@@ -32,125 +20,11 @@ namespace CluedIn.Connector.SynapseDataEngineering
         /// <summary>Starts this instance.</summary>
         public override void Start()
         {
-            var databricksConstants = Container.Resolve<ISynapseDataEngineeringConstants>();
-            var jobDataFactory = Container.Resolve<SynapseDataEngineeringJobDataFactory>();
-
-            #region Set existing streams to EventMode
-            Task.Run(async () =>
-            {
-                try
-                {
-                    var upgradeSettingKey = "ADl Mode Migration";
-
-                    var dbContext = new CluedInEntities(Container.Resolve<DbContextOptions<CluedInEntities>>());
-                    var modeMigrationSetting = dbContext.Settings.FirstOrDefault(s =>
-                        s.OrganizationId == Guid.Empty && s.Key == upgradeSettingKey);
-                    if (modeMigrationSetting != null)
-                    {
-                        return;
-                    }
-
-                    var startedAt = DateTime.Now;
-
-                    IStreamRepository streamRepository = null;
-                    while (streamRepository == null)
-                    {
-                        if (DateTime.Now.Subtract(startedAt).TotalMinutes > 10)
-                        {
-                            Log.LogWarning($"Timeout resolving {nameof(IStreamRepository)}");
-                            return;
-                        }
-
-                        try
-                        {
-                            streamRepository = Container.Resolve<IStreamRepository>();
-                        }
-                        catch
-                        {
-                            await Task.Delay(1000);
-                        }
-                    }
-
-                    var streams = streamRepository.GetAllStreams().ToList();
-
-                    var organizationIds = streams.Select(s => s.OrganizationId).Distinct().ToArray();
-
-                    foreach (var orgId in organizationIds)
-                    {
-                        var org = new Organization(ApplicationContext, orgId);
-
-                        foreach (var provider in org.Providers.AllProviderDefinitions.Where(x =>
-                                     x.ProviderId == databricksConstants.ProviderId))
-                        {
-                            foreach (var stream in streams.Where(s => s.ConnectorProviderDefinitionId == provider.Id))
-                            {
-                                if (stream.Mode != StreamMode.EventStream)
-                                {
-                                    var executionContext = ApplicationContext.CreateExecutionContext(orgId);
-
-                                    var model = new SetupConnectorModel
-                                    {
-                                        ConnectorProviderDefinitionId = provider.Id,
-                                        Mode = StreamMode.EventStream,
-                                        ContainerName = stream.ContainerName,
-                                        DataTypes =
-                                            (await streamRepository.GetStreamMappings(stream.Id))
-                                            .Select(x => new DataTypeEntry
-                                            {
-                                                Key = x.SourceDataType,
-                                                Type = x.SourceObjectType
-                                            }).ToList(),
-                                        ExistingContainerAction = ExistingContainerActionEnum.Archive,
-                                        ExportIncomingEdges = stream.ExportIncomingEdges,
-                                        ExportOutgoingEdges = stream.ExportOutgoingEdges,
-                                        OldContainerName = stream.ContainerName,
-                                    };
-
-                                    Log.LogInformation($"Setting {nameof(StreamMode.EventStream)} for stream '{{StreamName}}' ({{StreamId}})", stream.Name, stream.Id);
-
-                                    await streamRepository.SetupConnector(stream.Id, model, executionContext);
-                                }
-                            }
-                        }
-                    }
-
-                    dbContext.Settings.Add(new Setting
-                    {
-                        Id = Guid.NewGuid(),
-                        OrganizationId = Guid.Empty,
-                        UserId = Guid.Empty,
-                        Key = upgradeSettingKey,
-                        Data = "Complete",
-                    });
-                    await dbContext.SaveChangesAsync();
-                }
-                catch (Exception ex)
-                {
-                    Log.LogError(ex, $"{ComponentName}: Upgrade error");
-                }
-            });
-            #endregion
-
-            var exportEntitiesJobType = typeof(SynapseDataEngineeringExportEntitiesJob);
-            SubscribeToEvents(databricksConstants, exportEntitiesJobType);
-            _ = Task.Run(() => RunScheduler(databricksConstants, jobDataFactory, exportEntitiesJobType));
-
-            Log.LogInformation($"{ComponentName} Registered");
-            State = ServiceState.Started;
+            DefaultStartInternal<ISynapseDataEngineeringConstants, SynapseDataEngineeringJobDataFactory, SynapseDataEngineeringExportEntitiesJob>();
         }
-
-        /// <summary>Stops this instance.</summary>
-        public override void Stop()
-        {
-            if (State == ServiceState.Stopped)
-            {
-                return;
-            }
-
-            State = ServiceState.Stopped;
-        }
-
 
         public const string ComponentName = "Synapse Data Engineering";
+
+        protected override string ConnectorComponentName => ComponentName;
     }
 }


### PR DESCRIPTION
## Description
Work Item ID: [AB#41528](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/41528) [AB#42313](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/42313)

Teh reason for error during deactivation is because account id is set to empty string. 
When it is an empty string, server deserializes the accuont id as null and tries to find an export target with null, which does nto exist. 

This PR sets the accoutn id to be ProviderId-ProviderDefinitionId. account id MUST be a unique value. Server does not allow multiple export targets  using same connector with same account id 

## How has it been tested?
Manually in local environment