### PR TITLE
fix: Validate stream cache related options only when stream cache is enabled

### DIFF
--- a/src/Connector.DataLake.Common/DataLakeConstants.cs
+++ b/src/Connector.DataLake.Common/DataLakeConstants.cs
@@ -195,6 +195,16 @@ public abstract class DataLakeConstants : ConfigurationConstantsBase, IDataLakeC
                        Variables can also be formatted using formatString modifier. For more information, please refer to the documentation.
                        """,
                 IsRequired = false,
+                DisplayDependencies = new[]
+                {
+                    new ControlDisplayDependency
+                    {
+                        Name = Schedule,
+                        Operator = ControlDependencyOperator.Equals,
+                        Value = CustomCronScheduleName,
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    },
+                },
             });
 
         return controls;


### PR DESCRIPTION

## Description
Work Item ID: [AB#43217](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43217) 



## How has it been tested? 
Locally, manually