### PR TITLE
fix: Update display dependencies for CustomCron and FileNamePattern

### DIFF
--- a/src/Connector.DataLake.Common/DataLakeConstants.cs
+++ b/src/Connector.DataLake.Common/DataLakeConstants.cs
@@ -176,10 +176,16 @@ public abstract class DataLakeConstants : ConfigurationConstantsBase, IDataLakeC
                 {
                     new ControlDisplayDependency
                     {
+                        Name = IsStreamCacheEnabled,
+                        Operator = ControlDependencyOperator.Exists,
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    },
+                    new ControlDisplayDependency
+                    {
                         Name = Schedule,
                         Operator = ControlDependencyOperator.Equals,
                         Value = CustomCronScheduleName,
-                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Disabled,
                     },
                 },
             });
@@ -195,6 +201,15 @@ public abstract class DataLakeConstants : ConfigurationConstantsBase, IDataLakeC
                        Variables can also be formatted using formatString modifier. For more information, please refer to the documentation.
                        """,
                 IsRequired = false,
+                DisplayDependencies = new[]
+                {
+                    new ControlDisplayDependency
+                    {
+                        Name = IsStreamCacheEnabled,
+                        Operator = ControlDependencyOperator.Exists,
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    },
+                },
             });
 
         return controls;


### PR DESCRIPTION

## Description
Work Item ID: [AB#43217](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43217) 

Work around the problem of custom cron being invisible when stream cache is disabled and then enabled


## How has it been tested? 
Manually,Locally