### PR TITLE
fix: Set custom cron not required so that hourly/daily/weekly schedule can show test connection enabled

### DIFF
--- a/src/Connector.DataLake.Common/DataLakeConstants.cs
+++ b/src/Connector.DataLake.Common/DataLakeConstants.cs
@@ -164,7 +164,7 @@ public abstract class DataLakeConstants : ConfigurationConstantsBase, IDataLakeC
                 DisplayName = "Custom Cron",
                 Type = "input",
                 Help = utcExportHelpText,
-                IsRequired = true,
+                IsRequired = false,
                 DataDependencies = new[]
                 {
                     new ControlDataDependency


### PR DESCRIPTION

## Description
Work Item ID: [AB#43217](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43217) 
If you have some value in CustomCron, test connection button is enabled but when you don't have any value, the test connection button is disabled. This PR sets the custom cron to be optional. Validation still works if you do not key in any value when selecting custom schedule or if you key in invalid cron schedule 



## How has it been tested?
Locally, manually