### PR TITLE
fix: Set custom cron expression  to be hidden when schedule is not CustomCron

### DIFF
--- a/src/Connector.DataLake.Common/DataLakeConstants.cs
+++ b/src/Connector.DataLake.Common/DataLakeConstants.cs
@@ -185,7 +185,7 @@ public abstract class DataLakeConstants : ConfigurationConstantsBase, IDataLakeC
                         Name = Schedule,
                         Operator = ControlDependencyOperator.Equals,
                         Value = CustomCronScheduleName,
-                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Disabled,
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
                     },
                 },
             });


### PR DESCRIPTION

## Description
Work Item ID: [AB#43217](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/43217)


## How has it been tested?
Manually, locally