### PR TITLE
fix: Do not output warning logs when job is not present in job queue

### DIFF
--- a/docs/4.4.1-release-notes.md
+++ b/docs/4.4.1-release-notes.md
@@ -1,3 +1,4 @@
 ### Fixes
+- Prevent unnecessary warning messages when using sync mode with stream cache disabled
 - Add option to enable or disable escaping of non a-z,A-Z,0-9,_ characters
 - Add option to enable or disable writing of guids as strings


### PR DESCRIPTION

## Description
Work Item ID: [AB#44195](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/44195)
Reduce warning messages

## How has it been tested?
Locally, manually

## Release Note
Prevent unnecessary warning messages when using sync mode with stream cache disabled