### PR TITLE
fix: Add option to not escape vocabulary keys and not write guid as string

### DIFF
--- a/src/Connector.AzureDataLake/AzureDataLakeConnectorJobData.cs
+++ b/src/Connector.AzureDataLake/AzureDataLakeConnectorJobData.cs
@@ -19,10 +19,6 @@ internal class AzureDataLakeConnectorJobData : DataLakeJobData
     public string DirectoryName => GetConfigurationValue(AzureDataLakeConstants.DirectoryName) as string;
     public string FileSystemName => GetConfigurationValue(AzureDataLakeConstants.FileSystemName) as string;
 
-    public override bool ShouldEscapeVocabularyKeys => IsStreamCacheEnabled && DataLakeConstants.OutputFormats.Parquet.Equals(OutputFormat, StringComparison.OrdinalIgnoreCase);
-
-    public override bool ShouldWriteGuidAsString => ShouldEscapeVocabularyKeys;
-
     protected override void AddToHashCode(HashCode hash)
     {
         hash.Add(AccountName);

--- a/src/Connector.AzureDataLake/AzureDataLakeConstants.cs
+++ b/src/Connector.AzureDataLake/AzureDataLakeConstants.cs
@@ -66,6 +66,52 @@ public class AzureDataLakeConstants : DataLakeConstants, IAzureDataLakeConstants
         };
 
         controls.AddRange(GetAuthMethods(applicationContext));
+        controls.Add(
+            new()
+            {
+                Name = ShouldEscapeVocabularyKeys,
+                DisplayName = "Replace Non-Alphanumeric Characters in Column Names",
+                Type = "checkbox",
+                IsRequired = false,
+                Help = """
+                    Replaces characters in the column names that are not in this list ('a-z', 'A-Z', '0-9' and '_') with the character '_'.
+                    Enable this if you plan to access the output file in Microsoft Purview.
+                    """,
+                DisplayDependencies = new[]
+                {
+                    new ControlDisplayDependency
+                    {
+                        Name = OutputFormat,
+                        Operator = ControlDependencyOperator.Equals,
+                        Value = OutputFormats.Parquet.ToLowerInvariant(),
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    },
+                },
+            }
+        );
+        controls.Add(
+            new()
+            {
+                Name = ShouldWriteGuidAsString,
+                DisplayName = "Write Guid as string",
+                Type = "checkbox",
+                IsRequired = false,
+                Help = """
+                    Write Guid values as string instead of byte array.
+                    Enable this if you plan to access the output file in Microsoft Purview.
+                    """,
+                DisplayDependencies = new[]
+                {
+                    new ControlDisplayDependency
+                    {
+                        Name = OutputFormat,
+                        Operator = ControlDependencyOperator.Equals,
+                        Value = OutputFormats.Parquet.ToLowerInvariant(),
+                        UnfulfilledAction = ControlDependencyUnfulfilledAction.Hidden,
+                    },
+                },
+            }
+        );
 
         return new AuthMethods
         {


### PR DESCRIPTION

## Description
Work Item ID: [AB#44595](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/44595)


## How has it been tested? 
Locally, manually

## Release Note
Add ability to enable or disable escaping of special character in column names in parquet file
Add ability to enable or disable writing of guid values as string in parquet file