### PR TITLE
chore: Fix Idle() logic after Flush()

### DIFF
--- a/src/Connector.DataLake.Common/Buffer.cs
+++ b/src/Connector.DataLake.Common/Buffer.cs
@@ -34,7 +34,7 @@ namespace CluedIn.Connector.DataLake.Common
 
         private DateTime _lastAdded;
 
-        private readonly CancellationTokenSource _idleCancellationTokenSource;
+        private CancellationTokenSource _idleCancellationTokenSource;
 
         private readonly int _autoMaxSizeDetectionSampleSize = 3;   // twice is a coincidence, three times is a pattern
 
@@ -166,11 +166,11 @@ namespace CluedIn.Connector.DataLake.Common
             var t = _idleTask;
             if (t != null)
             {
-                Console.WriteLine("Canceling");
                 _idleCancellationTokenSource.Cancel();
-                Console.WriteLine("Canceled");
 
                 await t;
+
+                _idleCancellationTokenSource = new();
             }
         }
 


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Fix `Idle()` not working correctly after `Flush()`, as we cancel cancellation token. So if you invoke e.g. `Add()` after `Flush()` - it will not wait anymore at the beginning. Fix it by re-creating the cancellation token source, as there is no way to reset it.

Also remove console logging to not confuse people reading output logs :)