### PR TITLE
fix: Prevent exception when exporting when load to table is disabled

### DIFF
--- a/src/Connector.OneLake/Connector/OneLakeExportEntitiesJob.cs
+++ b/src/Connector.OneLake/Connector/OneLakeExportEntitiesJob.cs
@@ -5,6 +5,8 @@ using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Core;
 using CluedIn.Core.Streams;
 
+using Microsoft.Extensions.Logging;
+
 namespace CluedIn.Connector.OneLake.Connector;
 
 internal class OneLakeExportEntitiesJob : DataLakeExportEntitiesJobBase
@@ -26,6 +28,18 @@ internal class OneLakeExportEntitiesJob : DataLakeExportEntitiesJobBase
     private protected override async Task PostExportAsync(ExecutionContext context, ExportJobData exportJobData)
     {
         var jobData = exportJobData.DataLakeJobData as OneLakeConnectorJobData;
+        if (!jobData.ShouldLoadToTable)
+        {
+            context.Log.LogDebug("Skipping loading to table as the job data does not require it.");
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(jobData.TableName))
+        {
+            context.Log.LogWarning("Skipping loading to table as the table name is not specified.");
+            return;
+        }
+
         var replacedTableName = await ReplaceNameUsingPatternAsync(
             context,
             jobData.TableName,


### PR DESCRIPTION

## Description
Work Item ID:[AB#48700](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48700)


## How has it been tested? 
Locally, manually

## Release Note
Fixed error when exporting causes exception when load to Lakehouse table is disabled