### PR TITLE
fix: Prevent exception when verifying cron schedule

### DIFF
--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -509,7 +509,13 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     return new ConnectionVerificationResult(false, errorMessage);
                 }
 
-                if (!CronSchedules.TryGetCronSchedule(jobData.GetCronOrScheduleName(), out _))
+                var cronOrScheduleName = jobData.GetCronOrScheduleName();
+                if (string.IsNullOrWhiteSpace(cronOrScheduleName))
+                {
+                    return new ConnectionVerificationResult(false, "Schedule name cannot be empty.");
+                }
+
+                if (!CronSchedules.TryGetCronSchedule(cronOrScheduleName, out _))
                 {
                     var supported = string.Join(',', CronSchedules.SupportedCronScheduleNames);
                     var errorMessage = $"Schedule '{jobData.Schedule}' with cron '{jobData.CustomCron}' is not supported. Supported schedules are {supported} and valid cron expression.";


### PR DESCRIPTION

## Description
Work Item ID: [AB#48705](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48705)
Fixed error when verifying connection in export target edit page when custom cron is selected and schedule is empty

## How has it been tested? 
Locally , manually

## Release Note 
Fixed error when verifying connection in export target edit page when custom cron is selected and schedule is empty