### PR TITLE
fix: Properly set row marker position and value

### DIFF
--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,0 +1,2 @@
+### Fixes
+- Fix issue where rows are not updated in Open Mirroring when entities are updated

--- a/src/Connector.DataLake.Common/Connector/SqlDataWriter/SqlDataWriterBase.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlDataWriter/SqlDataWriterBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.IO;
@@ -35,9 +35,15 @@ internal abstract class SqlDataWriterBase : ISqlDataWriter
     {
         context.Log.LogInformation("Begin writing output.");
 
-        var totalProcessed = await WriteOutputAsync(context, configuration, outputStream, fieldNames, reader);
+        var orderedFieldNames = OrderFields(context, configuration, fieldNames);
+        var totalProcessed = await WriteOutputAsync(context, configuration, outputStream, orderedFieldNames, reader);
         context.Log.LogInformation("End writing output. Total processed: {TotalProcessed}.", totalProcessed);
         return totalProcessed;
+    }
+
+    protected virtual ICollection<string> OrderFields(ExecutionContext context, IDataLakeJobData configuration, ICollection<string> fieldNames)
+    {
+        return fieldNames;
     }
 
     public abstract Task<long> WriteOutputAsync(

--- a/src/Connector.FabricOpenMirroring/Connector/SqlDataWriter/OpenMirroringParquetSqlDataWriter.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/SqlDataWriter/OpenMirroringParquetSqlDataWriter.cs
@@ -24,6 +24,7 @@ internal class OpenMirroringParquetSqlDataWriter : ParquetSqlDataWriter
 
         return orderedFields;
     }
+
     protected override DataField GetParquetDataField(string fieldName, Type type, IDataLakeJobData configuration)
     {
         if (fieldName.Equals(DataLakeConstants.ChangeTypeKey, StringComparison.Ordinal))

--- a/src/Connector.FabricOpenMirroring/Connector/SqlDataWriter/OpenMirroringParquetSqlDataWriter.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/SqlDataWriter/OpenMirroringParquetSqlDataWriter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using CluedIn.Connector.DataLake.Common;
 using CluedIn.Connector.DataLake.Common.Connector.SqlDataWriter;
+using CluedIn.Core;
 using CluedIn.Core.Data.Parts;
 
 using Microsoft.Data.SqlClient;
@@ -14,6 +15,15 @@ namespace CluedIn.Connector.FabricOpenMirroring.Connector.SqlDataWriter;
 internal class OpenMirroringParquetSqlDataWriter : ParquetSqlDataWriter
 {
     private const string RowMarkerKey = "__rowMarker__";
+
+    protected override ICollection<string> OrderFields(ExecutionContext context, IDataLakeJobData configuration, ICollection<string> fieldNames)
+    {
+        var orderedFields = new List<string>(fieldNames);
+        orderedFields.Remove(DataLakeConstants.ChangeTypeKey);
+        orderedFields.Add(DataLakeConstants.ChangeTypeKey);
+
+        return orderedFields;
+    }
     protected override DataField GetParquetDataField(string fieldName, Type type, IDataLakeJobData configuration)
     {
         if (fieldName.Equals(DataLakeConstants.ChangeTypeKey, StringComparison.Ordinal))
@@ -39,7 +49,7 @@ internal class OpenMirroringParquetSqlDataWriter : ParquetSqlDataWriter
             var value = changeType switch
             {
                 VersionChangeType.Removed => 2,
-                _ => 3,
+                _ => 4,
             };
             return value.ToString();
         }


### PR DESCRIPTION
## Description
Work Item ID: [AB#49324](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/49324)
Fix Open Mirroring export not updating rows because row marker value is not properly set.

## How has it been tested?
Locally, manually

## Release Note 
Fix Open Mirroring export not updating rows

## Notable Changes 
Need to stop and start stream after this fix has been deployed
