### PR TITLE
fix: Delete not reflected in export

### DIFF
--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -359,7 +359,9 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                         BEGIN
                             UPDATE [{tableName}]
                             SET
-                                [{DataLakeConstants.ChangeTypeKey}] = {syncItem.ChangeType.ToString()}
+                                [{DataLakeConstants.ChangeTypeKey}] = @ChangeType,
+                                [Timestamp] = @Timestamp,
+                                [Epoch] = @Epoch
                             WHERE {DataLakeConstants.IdKey} = @{DataLakeConstants.IdKey};
                         END
                         """;
@@ -368,6 +370,9 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     CommandType = CommandType.Text
                 };
                 command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
+                command.Parameters.Add(new SqlParameter($"@ChangeType", syncItem.ChangeType.ToString()));
+                command.Parameters.Add(new SqlParameter($"@Timestamp", syncItem.Data["Timestamp"]));
+                command.Parameters.Add(new SqlParameter($"@Epoch", syncItem.Data["Epoch"]));
 
                 var rowsAffected = await command.ExecuteNonQueryAsync();
                 if (rowsAffected != 1)

--- a/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
@@ -214,7 +214,7 @@ internal abstract class DataLakeExportEntitiesJobBase : DataLakeJobBase
             var sqlDataWriter = GetSqlDataWriter(outputFormat);
             await using var outputStream = await temporaryFileClient.OpenWriteAsync(configuration.IsOverwriteEnabled);
             using var bufferedStream = new DataLakeBufferedWriteStream(outputStream);
-            return await sqlDataWriter?.WriteAsync(context, configuration, bufferedStream, fieldNamesToUse, reader);
+            return await sqlDataWriter?.WriteAsync(context, configuration, bufferedStream, fieldNamesToUse, IsInitialExport, reader);
         }
 
         async Task setFilePropertiesAsync()
@@ -278,6 +278,8 @@ internal abstract class DataLakeExportEntitiesJobBase : DataLakeJobBase
     }
 
     private protected ExportHistory LastExport { get; private set; }
+
+    protected virtual bool IsInitialExport => LastExport == null;
 
     private protected virtual bool GetIsEmptyFileAllowed(ExportJobData exportJobData) => true;
 

--- a/src/Connector.DataLake.Common/Connector/SqlDataWriter/CsvSqlDataWriter.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlDataWriter/CsvSqlDataWriter.cs
@@ -18,6 +18,7 @@ internal class CsvSqlDataWriter : SqlDataWriterBase
         IDataLakeJobData configuration,
         Stream outputStream,
         ICollection<string> fieldNames,
+        bool isInitialExport,
         SqlDataReader reader)
     {
         context.Log.LogInformation("Begin writing output.");
@@ -36,6 +37,11 @@ internal class CsvSqlDataWriter : SqlDataWriterBase
         var totalProcessed = 0L;
         while (await reader.ReadAsync())
         {
+            if (ShouldSkip(configuration, isInitialExport, reader))
+            {
+                continue;
+            }
+
             var fieldValues = fieldNames.Select(name => GetValue(name, reader, configuration));
             foreach (var field in fieldValues)
             {

--- a/src/Connector.DataLake.Common/Connector/SqlDataWriter/ISqlDataWriter.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlDataWriter/ISqlDataWriter.cs
@@ -13,5 +13,6 @@ internal interface ISqlDataWriter
         IDataLakeJobData configuration,
         Stream outputStream,
         ICollection<string> fieldNames,
+        bool isInitialExport,
         SqlDataReader reader);
 }

--- a/src/Connector.DataLake.Common/Connector/SqlDataWriter/JsonSqlDataWriter.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlDataWriter/JsonSqlDataWriter.cs
@@ -16,6 +16,7 @@ internal class JsonSqlDataWriter : SqlDataWriterBase
         IDataLakeJobData configuration,
         Stream outputStream,
         ICollection<string> fieldNames,
+        bool isInitialExport,
         SqlDataReader reader)
     {
         await using var stringWriter = new StreamWriter(outputStream);
@@ -26,10 +27,15 @@ internal class JsonSqlDataWriter : SqlDataWriterBase
         await writer.WriteStartArrayAsync();
         while (await reader.ReadAsync())
         {
+            if (ShouldSkip(configuration, isInitialExport, reader))
+            {
+                continue;
+            }
+
             await writer.WriteStartObjectAsync();
 
             foreach(var field in fieldNames)
-            { 
+            {
                 await writer.WritePropertyNameAsync(field);
                 var value = GetValue(field, reader, configuration);
                 if (value is JArray jArray)

--- a/src/Connector.DataLake.Common/Connector/SqlDataWriter/ParquetSqlDataWriter.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlDataWriter/ParquetSqlDataWriter.cs
@@ -34,6 +34,7 @@ internal class ParquetSqlDataWriter : SqlDataWriterBase
         IDataLakeJobData configuration,
         Stream outputStream,
         ICollection<string> fieldNames,
+        bool isInitialExport,
         SqlDataReader reader)
     {
         var fields = new List<Field>();
@@ -51,6 +52,11 @@ internal class ParquetSqlDataWriter : SqlDataWriterBase
 
         while (await reader.ReadAsync())
         {
+            if (ShouldSkip(configuration, isInitialExport, reader))
+            {
+                continue;
+            }
+
             var fieldValues = fieldNames.Select(key => {
                 var value = GetValue(key, reader, configuration);
                 return value;


### PR DESCRIPTION
## Description
Work Item ID: AB#49481

OpenMirroring: Fixed exception when handling entity deletes.
OpenMirroring: Fixed deleted entity being exported on first export

## How has it been tested? 
Locally, manually

## Release Note 
Fixed delete not reflected in exports