### PR TITLE
fix: CSV export replication and _partnerEvents.json

### DIFF
--- a/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
@@ -7,8 +7,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Transactions;
 
-using Apache.Arrow;
-
 using Azure.Storage.Files.DataLake;
 
 using CluedIn.Connector.DataLake.Common.Connector.SqlDataWriter;
@@ -19,8 +17,6 @@ using CluedIn.Core.Streams.Models;
 
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
-
-using Parquet;
 
 namespace CluedIn.Connector.DataLake.Common.Connector;
 
@@ -117,7 +113,7 @@ internal abstract class DataLakeExportEntitiesJobBase : DataLakeJobBase
 
         var subDirectory = await GetSubDirectory(configuration, streamId);
         var directoryClient = await _dataLakeClient.EnsureDataLakeDirectoryExist(configuration, subDirectory);
-        await InitializeDirectoryAsync(configuration, exportJobData, directoryClient);
+        await InitializeDirectoryAsync(context, connection, configuration, exportJobData, directoryClient);
         var startExportTime = _dateTimeOffsetProvider.GetCurrentUtcTime();
         var exportHistory = new ExportHistory(
             streamId,
@@ -293,7 +289,7 @@ internal abstract class DataLakeExportEntitiesJobBase : DataLakeJobBase
         return Task.FromResult(string.Empty);
     }
 
-    private protected virtual Task InitializeDirectoryAsync(IDataLakeJobData configuration, ExportJobData exportJobData, DataLakeDirectoryClient client)
+    private protected virtual Task InitializeDirectoryAsync(ExecutionContext context, SqlConnection connection, IDataLakeJobData configuration, ExportJobData exportJobData, DataLakeDirectoryClient client)
     {
         return Task.CompletedTask;
     }

--- a/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
@@ -149,7 +149,6 @@ internal class OpenMirroringExportEntitiesJob : DataLakeExportEntitiesJobBase
                       "cluedInServerFileVersion": "{{_cluedInCoreFileVersionInfo.ProductVersion}}",
                       "organizationId": "{{exportJobData.StreamModel.OrganizationId:N}}",
                       "providerDefinitionId": "{{exportJobData.ProviderDefinition.Id:N}}",
-                      "streamId": "{{exportJobData.StreamId:N}}",
                       "createdAt": "{{DateTimeOffsetProvider.GetCurrentUtcTime().ToString("o")}}"
                     }
                   }

--- a/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
@@ -96,7 +96,7 @@ internal class OpenMirroringExportEntitiesJob : DataLakeExportEntitiesJobBase
                            "rowSeparator": "\n",
                            "columnSeparator": ",",
                            "quoteCharacter": "\"",
-                           "escapeCharacter": "\\",
+                           "escapeCharacter": "\"",
                            "nullValue": "",
                            "encoding": "UTF-8"
                        }

--- a/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
@@ -16,11 +16,13 @@ using CluedIn.Core;
 using CluedIn.Core.Streams;
 
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
 
 namespace CluedIn.Connector.FabricOpenMirroring.Connector;
 
 internal class OpenMirroringExportEntitiesJob : DataLakeExportEntitiesJobBase
 {
+    private const int PartnerEventsJsonLockInMilliseconds = 100;
     private static readonly AssemblyName _connectorAssemblyName = typeof(OpenMirroringExportEntitiesJob).Assembly.GetName();
     private static readonly AssemblyName _cluedInCoreAssemblyName = typeof(IDateTimeOffsetProvider).Assembly.GetName();
     private static readonly FileVersionInfo _connectorFileVersionInfo = FileVersionInfo.GetVersionInfo(typeof(OpenMirroringExportEntitiesJob).Assembly.Location);
@@ -59,16 +61,56 @@ internal class OpenMirroringExportEntitiesJob : DataLakeExportEntitiesJobBase
 
     private protected override bool GetIsEmptyFileAllowed(ExportJobData exportJobData) => false;
 
-    private protected override async Task InitializeDirectoryAsync(IDataLakeJobData configuration, ExportJobData exportJobData, DataLakeDirectoryClient directoryClient)
+    private protected override async Task InitializeDirectoryAsync(ExecutionContext context, SqlConnection connection, IDataLakeJobData configuration, ExportJobData exportJobData, DataLakeDirectoryClient directoryClient)
     {
-        await CreateMetadataJsonIfNotExists(directoryClient);
         await CreatePartnerEventsJsonIfNotExists(directoryClient);
+        await EnsureMetadataJsonExists(directoryClient);
 
-        static async Task CreateMetadataJsonIfNotExists(DataLakeDirectoryClient directoryClient)
+        async Task EnsureMetadataJsonExists(DataLakeDirectoryClient directoryClient)
+        {
+            if (configuration.OutputFormat == DataLakeConstants.OutputFormats.Csv)
+            {
+                await EnsureCsvMetadataJsonExists(directoryClient);
+            }
+            else
+            {
+                await EnsureGenericMetadataJsonExists(directoryClient);
+            }
+        }
+
+        async Task EnsureCsvMetadataJsonExists(DataLakeDirectoryClient directoryClient)
         {
             var fileClient = directoryClient.GetFileClient("_metadata.json");
 
-            if (!await fileClient.ExistsAsync())
+            if (IsInitialExport || !await fileClient.ExistsAsync())
+            {
+                await using var outputStream = await fileClient.OpenWriteAsync(true);
+                await outputStream.WriteAsync(Encoding.UTF8.GetBytes(
+                    $$"""
+                    {
+                       "keyColumns": ["Id"],
+                       "fileExtension": "csv",
+                       "fileFormat": "csv",
+                       "fileFormatTypeProperties": {
+                           "firstRowAsHeader": true,
+                           "rowSeparator": "\n",
+                           "columnSeparator": ",",
+                           "quoteCharacter": "\"",
+                           "escapeCharacter": "\\",
+                           "nullValue": "",
+                           "encoding": "UTF-8"
+                       }
+                    }
+                    """));
+                await outputStream.FlushAsync();
+            }
+        }
+
+        async Task EnsureGenericMetadataJsonExists(DataLakeDirectoryClient directoryClient)
+        {
+            var fileClient = directoryClient.GetFileClient("_metadata.json");
+
+            if (IsInitialExport || !await fileClient.ExistsAsync())
             {
                 await using var outputStream = await fileClient.OpenWriteAsync(true);
                 await outputStream.WriteAsync(Encoding.UTF8.GetBytes(

--- a/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
@@ -68,7 +68,7 @@ internal class OpenMirroringExportEntitiesJob : DataLakeExportEntitiesJobBase
 
         async Task EnsureMetadataJsonExists(DataLakeDirectoryClient directoryClient)
         {
-            if (configuration.OutputFormat == DataLakeConstants.OutputFormats.Csv)
+            if (DataLakeConstants.OutputFormats.Csv.Equals(configuration.OutputFormat, StringComparison.OrdinalIgnoreCase))
             {
                 await EnsureCsvMetadataJsonExists(directoryClient);
             }


### PR DESCRIPTION
## Description
Work Item ID: [AB#49525](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/49525) [AB#49526](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/49526)

OpenMirroring: _partnerEvent.json moved to LandingZone
OpenMirroring: csv replication to table fixed


## How has it been tested?
Locally, manually