### PR TITLE
fix: CSV export replication not working correctly

### DIFF
--- a/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/OpenMirroringExportEntitiesJob.cs
@@ -93,7 +93,7 @@ internal class OpenMirroringExportEntitiesJob : DataLakeExportEntitiesJobBase
                        "fileFormat": "csv",
                        "fileFormatTypeProperties": {
                            "firstRowAsHeader": true,
-                           "rowSeparator": "\n",
+                           "rowSeparator": "\r\n",
                            "columnSeparator": ",",
                            "quoteCharacter": "\"",
                            "escapeCharacter": "\"",


### PR DESCRIPTION
## Description
Work Item ID: [AB#50058](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/50058)

CSV export not being replicated correctly due to newline settings

## How has it been tested? 
Locally, manually