### PR TITLE
fix: Remove space validation because spaces are allowed for workspace name

### DIFF
--- a/docs/4.5.2-release-notes.md
+++ b/docs/4.5.2-release-notes.md
@@ -1,3 +1,4 @@
 ### Features
 
 ### Fixes
+Allow spaces in workspace name

--- a/src/Connector.OneLake/OneLakeConstants.cs
+++ b/src/Connector.OneLake/OneLakeConstants.cs
@@ -45,13 +45,6 @@ public class OneLakeConstants : DataLakeConstants, IOneLakeConstants
                 DisplayName = WorkspaceName,
                 Type = "input",
                 IsRequired = true,
-                ValidationRules = new List<Dictionary<string, string>>()
-                {
-                    new() {
-                        { "regex", "\\s" },
-                        { "message", "Spaces are not allowed" }
-                    }
-                },
             },
             new ()
             {


### PR DESCRIPTION
## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#53679](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/53679)


## How has it been tested? 
Locally, manually

## Release Note <!-- Remove if not needed -->
Allow spaces in workspace name

## Notable Changes <!-- Remove if not needed -->
