### PR TITLE
feat: Additional connector actions

### DIFF
--- a/src/Connector.AzureAIStudio/Connector/AzureAIStudioConnector.cs
+++ b/src/Connector.AzureAIStudio/Connector/AzureAIStudioConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Core;
@@ -11,11 +11,12 @@ public class AzureAIStudioConnector : DataLakeConnector
 {
     public AzureAIStudioConnector(
         ILogger<AzureAIStudioConnector> logger,
+        ApplicationContext applicationContext,
         AzureAIStudioClient client,
         IAzureAIStudioConstants constants,
         AzureAIStudioJobDataFactory dataLakeJobDataFactory,
         IDateTimeOffsetProvider dateTimeOffsetProvider)
-        : base(logger, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
+        : base(logger, applicationContext, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
     {
     }
 

--- a/src/Connector.AzureDataLake/Connector/AzureDataLakeConnector.cs
+++ b/src/Connector.AzureDataLake/Connector/AzureDataLakeConnector.cs
@@ -1,4 +1,4 @@
-﻿using CluedIn.Connector.DataLake.Common;
+using CluedIn.Connector.DataLake.Common;
 using System.Threading.Tasks;
 using System;
 
@@ -25,11 +25,12 @@ public class AzureDataLakeConnector : DataLakeConnector
 
     public AzureDataLakeConnector(
         ILogger<AzureDataLakeConnector> logger,
+        ApplicationContext applicationContext,
         AzureDataLakeClient client,
         IAzureDataLakeConstants constants,
         AzureDataLakeJobDataFactory dataLakeJobDataFactory,
         IDateTimeOffsetProvider dateTimeOffsetProvider)
-        : base(logger, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
+        : base(logger, applicationContext, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }

--- a/src/Connector.AzureDatabricks/Connector/AzureDatabricksConnector.cs
+++ b/src/Connector.AzureDatabricks/Connector/AzureDatabricksConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Core;
@@ -11,11 +11,12 @@ public class AzureDatabricksConnector : DataLakeConnector
 {
     public AzureDatabricksConnector(
         ILogger<AzureDatabricksConnector> logger,
+        ApplicationContext applicationContext,
         AzureDatabricksClient client,
         IAzureDatabricksConstants constants,
         AzureDatabricksJobDataFactory dataLakeJobDataFactory,
         IDateTimeOffsetProvider dateTimeOffsetProvider)
-        : base(logger, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
+        : base(logger, applicationContext, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
     {
     }
 

--- a/src/Connector.DataLake.Common/Buffers/Buffer.cs
+++ b/src/Connector.DataLake.Common/Buffers/Buffer.cs
@@ -177,6 +177,28 @@ namespace CluedIn.Connector.DataLake.Common.Buffers
             }
         }
 
+        Task<BufferStatus> IBuffer<T>.GetStatus()
+        {
+            var additionalInformation = new Dictionary<string, string>()
+            {
+                [nameof(_idleFlushHistory)] = string.Join(";", _idleFlushHistory.Select(h => $"Count:{h.itemCount},FlushedAt:{h.flushedAt},FlushDuration:{h.flushDuration.TotalSeconds}s")),
+                [nameof(_autoMaxSizeSetAt)] = _autoMaxSizeSetAt.ToString("o"),
+                [nameof(_addingCompleteSemaphore)] = _addingCompleteSemaphore.CurrentCount.ToString(),
+                [nameof(_addingSemaphore)] = _addingSemaphore.CurrentCount.ToString(),
+                [nameof(_flushSemaphore)] = _flushSemaphore.CurrentCount.ToString(),
+            };
+
+            for (var i = 0; i <_addingTaskSemaphores.Length; i++)
+            {
+                additionalInformation[$"{nameof(_addingTaskSemaphores)}[{i}]"] = _addingTaskSemaphores[i].CurrentCount.ToString();
+            }
+            return Task.FromResult(new BufferStatus(
+                TotalPendingItems: _currentCount,
+                MaxPendingItems: _maxSize,
+                TimeOutMilliseconds: _timeout,
+                AdditionalInformation: additionalInformation));
+        }
+
         private async Task Flush(bool idle)
         {
             await _flushSemaphore.WaitAsync();

--- a/src/Connector.DataLake.Common/Buffers/ChannelBasedBuffer.cs
+++ b/src/Connector.DataLake.Common/Buffers/ChannelBasedBuffer.cs
@@ -214,6 +214,15 @@ internal sealed class ChannelBasedBuffer<T> : IDisposable, IAsyncDisposable, IBu
         return FlushAsync(default);
     }
 
+    Task<BufferStatus> IBuffer<T>.GetStatus()
+    {
+        return Task.FromResult(new BufferStatus(
+            TotalPendingItems: _channel.Reader.Count,
+            MaxPendingItems: _maxBatchSize,
+            TimeOutMilliseconds: (int)_options.IdleTimeout.TotalMilliseconds,
+            new Dictionary<string, string>()));
+    }
+
     /// <summary>Add item and complete only when that item is flushed.</summary>
     public async Task AddAsync(T item, CancellationToken cancellationToken = default)
     {

--- a/src/Connector.DataLake.Common/Buffers/SafeBuffer.cs
+++ b/src/Connector.DataLake.Common/Buffers/SafeBuffer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -88,6 +89,15 @@ internal sealed class SafeBuffer<TItem, TResult> : IDisposable, IBuffer<TItem>
         {
             await ExecuteBatchCore(batchToFlush);
         }
+    }
+
+    Task<BufferStatus> IBuffer<TItem>.GetStatus()
+    {
+        return Task.FromResult(new BufferStatus(
+            TotalPendingItems: _currentBatch.Count,
+            MaxPendingItems: _maxSize,
+            TimeOutMilliseconds: _timeoutMs,
+            new Dictionary<string, string>()));
     }
 
     public async Task<TResult> Add(TItem item, CancellationToken ct = default)

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
@@ -154,7 +154,7 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         var bufferStatus = new ConcurrentDictionary<string, BufferStatus>();
         var timeOutInMilliseconds =
             request?.Parameters?.TryGetValue("TimeOutInMilliseconds", out var timeOutObj) == true &&
-            int.TryParse(timeOutObj?.ToString(), out var parsedTimeOut)
+            int.TryParse(timeOutObj?.ToString(), out var parsedTimeOut) && parsedTimeOut > 0
                 ? Math.Min(parsedTimeOut, MaximumGetBufferTimeOutInMilliseconds)
                 : MaximumGetBufferTimeOutInMilliseconds;
 

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
@@ -152,8 +152,11 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         var start = _dateTimeOffsetProvider.GetCurrentUtcTime();
         var systemEvents = executionContext.ApplicationContext.System.Events;
         var bufferStatus = new ConcurrentDictionary<string, BufferStatus>();
-        var timeOutInMilliseconds = request?.Parameters?.TryGetValue("TimeOutInMilliseconds", out var timeOutObj) == true
-            && int.TryParse(timeOutObj.ToString(), out var parsedTimeOut)  ? Math.Min(parsedTimeOut, MaximumGetBufferTimeOutInMilliseconds): MaximumGetBufferTimeOutInMilliseconds;
+        var timeOutInMilliseconds =
+            request?.Parameters?.TryGetValue("TimeOutInMilliseconds", out var timeOutObj) == true &&
+            int.TryParse(timeOutObj?.ToString(), out var parsedTimeOut)
+                ? Math.Min(parsedTimeOut, MaximumGetBufferTimeOutInMilliseconds)
+                : MaximumGetBufferTimeOutInMilliseconds;
 
         await GetPeersBufferStatus();
 

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
@@ -3,15 +3,12 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 using CluedIn.Core;
 using CluedIn.Core.Connectors.ExtendedOperations;
-using CluedIn.Core.Data.Relational;
 using CluedIn.Core.Events;
 using CluedIn.Core.Jobs;
-using CluedIn.Core.Providers;
 using CluedIn.Core.Streams;
 using CluedIn.Core.Streams.Models;
 
@@ -31,6 +28,7 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
     private const string GetEntityActionName = "GetEntity";
     private const string GetExportHistoryActionName = "GetExportHistory";
     private const string GetBufferStatusActionName = "GetBufferStatus";
+    private const string GetConnectorVersionActionName = "GetConnectorVersion";
     private const int MaximumGetBufferTimeOutInMilliseconds = 10_000;
     private IDisposable _bufferStatusSubscription;
 
@@ -108,6 +106,11 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
                 return await GetBufferStatus(executionContext, streamModel, request);
             }
 
+            if (request.ActionName == GetConnectorVersionActionName)
+            {
+                return GetConnectorVersion(executionContext, streamModel, request);
+            }
+
             var now = _dateTimeOffsetProvider.GetCurrentUtcTime();
             var notFoundResult = new ExtendedOperationResultEntry("Result", ExtendedOperationResultEntryType.String, "Not Found", "Connector", string.Empty);
             return new ExecuteConnectorActionResult(streamModel.Id, request.ActionName, false, false, now, null, [notFoundResult]);
@@ -116,6 +119,32 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         {
             return GetFailedResult(streamModel, request, ex);
         }
+    }
+
+    private ExecuteConnectorActionResult GetConnectorVersion(ExecutionContext executionContext, IReadOnlyStreamModel streamModel, ExecuteConnectorActionRequest request)
+    {
+        var start = _dateTimeOffsetProvider.GetCurrentUtcTime();
+        return new ExecuteConnectorActionResult(
+            streamModel.Id,
+            request.ActionName,
+            IsSuccessful: true,
+            IsCompleted: true,
+            StartedAt: start,
+            CompletedAt: start,
+            [
+                new ExtendedOperationResultEntry(
+                    "ConnectorVersion",
+                    ExtendedOperationResultEntryType.String,
+                    GetType().Assembly.FullName,
+                    "Connector",
+                    string.Empty),
+                new ExtendedOperationResultEntry(
+                    "CommonVersion",
+                    ExtendedOperationResultEntryType.String,
+                    typeof(DataLakeConnector).Assembly.FullName,
+                    "Connector",
+                    string.Empty)
+            ]);
     }
 
     private async Task<ExecuteConnectorActionResult> GetBufferStatus(ExecutionContext executionContext, IReadOnlyStreamModel streamModel, ExecuteConnectorActionRequest request)

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
@@ -41,7 +41,6 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
     {
         await using var executionContext = _applicationContext.CreateExecutionContext(eventData.OrganizationId);
         var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, eventData.ProviderDefinitionId, eventData.ContainerName);
-        var hashCode = configuration.GetHashCode();
 
         if (_buffer.TryGet(configuration, out var buffer))
         {

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
@@ -1,15 +1,23 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
+using CluedIn.Core;
 using CluedIn.Core.Connectors.ExtendedOperations;
+using CluedIn.Core.Data.Relational;
+using CluedIn.Core.Events;
 using CluedIn.Core.Jobs;
+using CluedIn.Core.Providers;
 using CluedIn.Core.Streams;
 using CluedIn.Core.Streams.Models;
+
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+
 using Newtonsoft.Json;
 
 using ExecutionContext = CluedIn.Core.ExecutionContext;
@@ -22,6 +30,33 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
     private const string GetStreamCacheRowCountActionName = "GetStreamCacheRowCount";
     private const string GetEntityActionName = "GetEntity";
     private const string GetExportHistoryActionName = "GetExportHistory";
+    private const string GetBufferStatusActionName = "GetBufferStatus";
+    private const int MaximumGetBufferTimeOutInMilliseconds = 10_000;
+    private IDisposable _bufferStatusSubscription;
+
+    private void SetupBufferStatusSubscription()
+    {
+        _bufferStatusSubscription = _applicationContext.System.Events.SubscribeAsync<BufferStatusRequestedEvent>(ProcessBufferStatusRequestedEventAsync);
+    }
+
+    private async Task ProcessBufferStatusRequestedEventAsync(BufferStatusRequestedEvent eventData)
+    {
+        await using var executionContext = _applicationContext.CreateExecutionContext(eventData.OrganizationId);
+        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, eventData.ProviderDefinitionId, eventData.ContainerName);
+        var hashCode = configuration.GetHashCode();
+
+        if (_buffer.TryGet(configuration, out var buffer))
+        {
+            await _applicationContext.System.Events.PublishAsync(new BufferStatusRetrievedEvent
+            {
+                OrganizationId = eventData.OrganizationId,
+                StreamId = eventData.StreamId,
+                ContainerName = eventData.ContainerName,
+                ProviderDefinitionId = eventData.ProviderDefinitionId,
+                Status = await buffer.GetStatus(),
+            });
+        }
+    }
 
     public virtual async Task<GetConnectorActionsResult> GetActions(
         ExecutionContext executionContext,
@@ -31,6 +66,7 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
         var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
         var action = new ConnectorAction(RunExportActionName, "Run Export", "Run export now", [], []);
+
         var streamRepository = executionContext.ApplicationContext.Container.Resolve<IStreamRepository>();
 
         var stream = await streamRepository.GetStream(executionContext, streamModel.Id);
@@ -67,6 +103,11 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
                 return await GetExportHistory(executionContext, streamModel, request);
             }
 
+            if (request.ActionName == GetBufferStatusActionName)
+            {
+                return await GetBufferStatus(executionContext, streamModel, request);
+            }
+
             var now = _dateTimeOffsetProvider.GetCurrentUtcTime();
             var notFoundResult = new ExtendedOperationResultEntry("Result", ExtendedOperationResultEntryType.String, "Not Found", "Connector", string.Empty);
             return new ExecuteConnectorActionResult(streamModel.Id, request.ActionName, false, false, now, null, [notFoundResult]);
@@ -75,6 +116,59 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         {
             return GetFailedResult(streamModel, request, ex);
         }
+    }
+
+    private async Task<ExecuteConnectorActionResult> GetBufferStatus(ExecutionContext executionContext, IReadOnlyStreamModel streamModel, ExecuteConnectorActionRequest request)
+    {
+        var start = _dateTimeOffsetProvider.GetCurrentUtcTime();
+        var systemEvents = executionContext.ApplicationContext.System.Events;
+        var bufferStatus = new ConcurrentDictionary<string, BufferStatus>();
+        var timeOutInMilliseconds = request?.Parameters?.TryGetValue("TimeOutInMilliseconds", out var timeOutObj) == true
+            && int.TryParse(timeOutObj.ToString(), out var parsedTimeOut)  ? Math.Min(parsedTimeOut, MaximumGetBufferTimeOutInMilliseconds): MaximumGetBufferTimeOutInMilliseconds;
+
+        await GetPeersBufferStatus();
+
+        async Task GetPeersBufferStatus()
+        {
+            using var subscription = systemEvents.SubscribeAsync<BufferStatusRetrievedEvent>(retrievedEvent =>
+            {
+                if (retrievedEvent.OrganizationId == executionContext.Organization.Id
+                && retrievedEvent.StreamId == streamModel.Id)
+                {
+                    _ = bufferStatus.AddOrUpdate(retrievedEvent.OriginHost.MachineName, retrievedEvent.Status, (host, oldValue) =>
+                    {
+                        return retrievedEvent.Status;
+                    });
+                }
+
+                return Task.CompletedTask;
+            });
+
+            await systemEvents.PublishAsync(new BufferStatusRequestedEvent
+            {
+                OrganizationId = executionContext.Organization.Id,
+                StreamId = streamModel.Id,
+                ContainerName = streamModel.ContainerName,
+                ProviderDefinitionId = streamModel.ConnectorProviderDefinitionId.Value,
+            });
+
+            await Task.Delay(timeOutInMilliseconds);
+        }
+
+        var now = _dateTimeOffsetProvider.GetCurrentUtcTime();
+        var resultEntries = bufferStatus.Select(kvp => new ExtendedOperationResultEntry(
+            kvp.Key,
+            ExtendedOperationResultEntryType.Json,
+            JsonConvert.SerializeObject(kvp.Value),
+            "Connector",
+            string.Empty))
+            .ToList();
+        return new ExecuteConnectorActionResult(
+            streamModel.Id,
+            request.ActionName,
+            IsSuccessful: true, IsCompleted: true,
+            StartedAt: start,
+            CompletedAt: now, resultEntries);
     }
 
     private ExecuteConnectorActionResult GetFailedResult(
@@ -276,4 +370,30 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
     }
 
     protected abstract Type ExportJobType { get; }
+}
+
+public class BufferStatusRetrievedEvent : RemoteEvent
+{
+    public Guid OrganizationId { get; set; }
+
+    public Guid StreamId { get; set; }
+
+    public string ContainerName { get; set; }
+
+    public Guid ProviderDefinitionId { get; set; }
+
+    public BufferStatus Status { get; set; }
+
+
+}
+
+public class BufferStatusRequestedEvent : RemoteEvent
+{
+    public Guid OrganizationId { get; set; }
+
+    public Guid StreamId { get; set; }
+
+    public string ContainerName { get; set; }
+
+    public Guid ProviderDefinitionId { get; set; }
 }

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -31,6 +31,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         private static readonly string _invalidFileNameHasInvalidCharacters = $"File name contains invalid characters. It cannot have {string.Join(", ", _invalidFileNameCharacters.Select(c => $"'{c}'"))} characters";
         private const string InvalidFileNameStartsWithPeriodErrorMessage = "File name pattern cannot start with a period.";
         private readonly ILogger<DataLakeConnector> _logger;
+        private readonly ApplicationContext _applicationContext;
         private readonly IDataLakeClient _client;
         private readonly IDateTimeOffsetProvider _dateTimeOffsetProvider;
         private readonly IDataLakeJobDataFactory _dataLakeJobDataFactory;
@@ -62,6 +63,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
 
         protected DataLakeConnector(
             ILogger<DataLakeConnector> logger,
+            ApplicationContext applicationContext,
             IDataLakeClient client,
             IDataLakeConstants constants,
             IDataLakeJobDataFactory dataLakeJobDataFactory,
@@ -69,6 +71,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             : base(constants.ProviderId, false)
         {
             _logger = logger;
+            _applicationContext = applicationContext;
             _client = client;
             _dateTimeOffsetProvider = dateTimeOffsetProvider;
             _dataLakeJobDataFactory = dataLakeJobDataFactory;
@@ -85,11 +88,13 @@ namespace CluedIn.Connector.DataLake.Common.Connector
 
             _buffer = new PartitionedBuffer<IDataLakeJobData, string>(cacheRecordsThreshold,
                 backgroundFlushMaxIdleDefaultValue, Flush, dateTimeOffsetProvider, cacheBufferStrategy);
+            SetupBufferStatusSubscription();
         }
 
         ~DataLakeConnector()
         {
             _buffer.Dispose();
+            _bufferStatusSubscription?.Dispose();
         }
 
         public override Task VerifyExistingContainer(ExecutionContext executionContext, IReadOnlyStreamModel streamModel)

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -22,7 +22,7 @@ using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.Connector.DataLake.Common.Connector
 {
-    public abstract partial class DataLakeConnector : ConnectorBaseV2
+    public abstract partial class DataLakeConnector : ConnectorBaseV2, IDisposable
     {
         protected static readonly ConnectionVerificationResult SuccessfulConnectionVerification = new (true);
         private const string JsonMimeType = "application/json";
@@ -56,6 +56,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             [typeof(Guid)] = "UNIQUEIDENTIFIER",
             [typeof(string)] = "NVARCHAR(MAX)"
         };
+        private bool _disposedValue;
 
         protected IDataLakeJobDataFactory DataLakeJobDataFactory => _dataLakeJobDataFactory;
 
@@ -93,8 +94,28 @@ namespace CluedIn.Connector.DataLake.Common.Connector
 
         ~DataLakeConnector()
         {
-            _buffer.Dispose();
-            _bufferStatusSubscription?.Dispose();
+            Dispose(disposing: false);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    _buffer.Dispose();
+                    _bufferStatusSubscription?.Dispose();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
 
         public override Task VerifyExistingContainer(ExecutionContext executionContext, IReadOnlyStreamModel streamModel)

--- a/src/Connector.DataLake.Common/IBuffer.cs
+++ b/src/Connector.DataLake.Common/IBuffer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace CluedIn.Connector.DataLake.Common
@@ -7,5 +8,13 @@ namespace CluedIn.Connector.DataLake.Common
     {
         Task Add(T item);
         Task Flush();
+        Task<BufferStatus> GetStatus();
     }
 }
+
+
+public record BufferStatus(
+    int TotalPendingItems,
+    int MaxPendingItems,
+    int TimeOutMilliseconds,
+    Dictionary<string, string> AdditionalInformation);

--- a/src/Connector.DataLake.Common/IBuffer.cs
+++ b/src/Connector.DataLake.Common/IBuffer.cs
@@ -2,16 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace CluedIn.Connector.DataLake.Common
-{
-    internal interface IBuffer<T> : IDisposable
-    {
-        Task Add(T item);
-        Task Flush();
-        Task<BufferStatus> GetStatus();
-    }
-}
+namespace CluedIn.Connector.DataLake.Common;
 
+internal interface IBuffer<T> : IDisposable
+{
+    Task Add(T item);
+    Task Flush();
+    Task<BufferStatus> GetStatus();
+}
 
 public record BufferStatus(
     int TotalPendingItems,

--- a/src/Connector.DataLake.Common/PartitionedBuffer.cs
+++ b/src/Connector.DataLake.Common/PartitionedBuffer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 using CluedIn.Connector.DataLake.Common.Buffers;
@@ -40,7 +39,7 @@ namespace CluedIn.Connector.DataLake.Common
             _buffers = new Dictionary<TPartition, IBuffer<TItem>>();
         }
 
-        public bool TryGet(TPartition partition, out IBuffer<TItem?> item)
+        public bool TryGet(TPartition partition, out IBuffer<TItem>? item)
         {
             lock (_buffers)
             {

--- a/src/Connector.DataLake.Common/PartitionedBuffer.cs
+++ b/src/Connector.DataLake.Common/PartitionedBuffer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using CluedIn.Connector.DataLake.Common.Buffers;
@@ -37,6 +38,14 @@ namespace CluedIn.Connector.DataLake.Common
             _dateTimeOffsetProvider = dateTimeOffsetProvider ?? throw new ArgumentNullException(nameof(dateTimeOffsetProvider));
             _bufferStrategy = bufferStrategy;
             _buffers = new Dictionary<TPartition, IBuffer<TItem>>();
+        }
+
+        public bool TryGet(TPartition partition, out IBuffer<TItem?> item)
+        {
+            lock (_buffers)
+            {
+                return _buffers.TryGetValue(partition, out item);
+            }
         }
 
         public async Task Add(TPartition partition, TItem item)

--- a/src/Connector.FabricOpenMirroring/Connector/OpenMirroringConnector.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/OpenMirroringConnector.cs
@@ -29,11 +29,12 @@ public class OpenMirroringConnector : DataLakeConnector
 
     public OpenMirroringConnector(
         ILogger<OpenMirroringConnector> logger,
+        ApplicationContext applicationContext,
         OpenMirroringClient client,
         IOpenMirroringConstants constants,
         OpenMirroringJobDataFactory dataLakeJobDataFactory,
         IDateTimeOffsetProvider dateTimeOffsetProvider)
-        : base(logger, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
+        : base(logger, applicationContext, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _client = client ?? throw new ArgumentNullException(nameof(client));

--- a/src/Connector.OneLake/Connector/OneLakeConnector.cs
+++ b/src/Connector.OneLake/Connector/OneLakeConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -26,11 +26,12 @@ public class OneLakeConnector : DataLakeConnector
 
     public OneLakeConnector(
         ILogger<OneLakeConnector> logger,
+        ApplicationContext applicationContext,
         OneLakeClient client,
         IOneLakeConstants constants,
         OneLakeJobDataFactory dataLakeJobDataFactory,
         IDateTimeOffsetProvider dateTimeOffsetProvider)
-        : base(logger, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
+        : base(logger, applicationContext, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }

--- a/src/Connector.SynapseDataEngineering/Connector/SynapseDataEngineeringConnector.cs
+++ b/src/Connector.SynapseDataEngineering/Connector/SynapseDataEngineeringConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Core;
@@ -11,11 +11,12 @@ public class SynapseDataEngineeringConnector : DataLakeConnector
 {
     public SynapseDataEngineeringConnector(
         ILogger<SynapseDataEngineeringConnector> logger,
+        ApplicationContext applicationContext,
         SynapseDataEngineeringClient client,
         ISynapseDataEngineeringConstants constants,
         SynapseDataEngineeringJobDataFactory dataLakeJobDataFactory,
         IDateTimeOffsetProvider dateTimeOffsetProvider)
-        : base(logger, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
+        : base(logger, applicationContext, client, constants, dataLakeJobDataFactory, dateTimeOffsetProvider)
     {
     }
 

--- a/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
+++ b/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
@@ -640,12 +640,14 @@ public class AzureDataLakeConnectorTests : DataLakeConnectorTestsBase<AzureDataL
     }
 
     protected override Mock<AzureDataLakeConnector> GetConnectorMock(
+        ApplicationContext applicationContext,
         Mock<IDateTimeOffsetProvider> mockDateTimeOffsetProvider,
         Mock<IAzureDataLakeConstants> constantsMock,
         Mock<AzureDataLakeJobDataFactory> jobDataFactory)
     {
         var mockConnector = new Mock<AzureDataLakeConnector>(
             new Mock<ILogger<AzureDataLakeConnector>>().Object,
+            applicationContext,
             new AzureDataLakeClient(),
             constantsMock.Object,
             jobDataFactory.Object,

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
@@ -23,6 +23,7 @@ using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Data.Relational;
 using CluedIn.Core.Data.Vocabularies;
 using CluedIn.Core.DataStore;
+using CluedIn.Core.Events;
 using CluedIn.Core.Streams;
 using CluedIn.Core.Streams.Models;
 
@@ -70,6 +71,8 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
         var providerDefinitionId = Guid.Parse("c444cda8-d9b5-45cc-a82d-fef28e08d55c");
 
         var container = new WindsorContainer();
+        var systemEventsMock = new Mock<ISystemEvents>();
+        container.Register(Component.For<ISystemEvents>().Instance(systemEventsMock.Object));
         var applicationContext = new ApplicationContext(container);
 
         var mockDateTimeOffsetProvider = SetupDateTimeOffsetProvider(configureTimeProvider);
@@ -82,7 +85,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
 
         var constantsMock = CreateConstantsMock();
         var jobDataFactoryMock = CreateJobDataFactoryMock(container);
-        var connectorMock = GetConnectorMock(mockDateTimeOffsetProvider, constantsMock, jobDataFactoryMock);
+        var connectorMock = GetConnectorMock(applicationContext, mockDateTimeOffsetProvider, constantsMock, jobDataFactoryMock);
         jobDataFactoryMock.Setup(x => x.GetConfiguration(It.IsAny<ExecutionContext>(), providerDefinitionId, It.IsAny<string>()))
             .ReturnsAsync(jobData);
         connectorMock.CallBase = true;
@@ -201,6 +204,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
     }
 
     protected abstract Mock<TConnector> GetConnectorMock(
+        ApplicationContext applicationContext,
         Mock<IDateTimeOffsetProvider> mockDateTimeOffsetProvider,
         Mock<TConstants> constantsMock,
         Mock<TJobDataFactory> jobDataFactory);

--- a/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
+++ b/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
@@ -550,6 +550,7 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
     }
 
     protected override Mock<OpenMirroringConnector> GetConnectorMock(
+        ApplicationContext applicationContext,
         Mock<IDateTimeOffsetProvider> mockDateTimeOffsetProvider,
         Mock<IOpenMirroringConstants> constantsMock,
         Mock<OpenMirroringJobDataFactory> jobDataFactory)
@@ -557,6 +558,7 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
         var logger = new Mock<ILogger<OpenMirroringClient>>();
         var mockConnector = new Mock<OpenMirroringConnector>(
             new Mock<ILogger<OpenMirroringConnector>>().Object,
+            applicationContext,
             new OpenMirroringClient(logger.Object, mockDateTimeOffsetProvider.Object),
             constantsMock.Object,
             jobDataFactory.Object,

--- a/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
+++ b/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
@@ -607,6 +607,7 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
     }
 
     protected override Mock<OneLakeConnector> GetConnectorMock(
+        ApplicationContext applicationContext,
         Mock<IDateTimeOffsetProvider> mockDateTimeOffsetProvider,
         Mock<IOneLakeConstants> constantsMock,
         Mock<OneLakeJobDataFactory> jobDataFactory)
@@ -614,6 +615,7 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
         var logger = new Mock<ILogger<OneLakeClient>>();
         var mockConnector = new Mock<OneLakeConnector>(
             new Mock<ILogger<OneLakeConnector>>().Object,
+            applicationContext,
             new OneLakeClient(logger.Object),
             constantsMock.Object,
             jobDataFactory.Object,

--- a/test/unit/Connector.DataLake.Common.Tests.Unit/LegacyBufferTests.cs
+++ b/test/unit/Connector.DataLake.Common.Tests.Unit/LegacyBufferTests.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 using CluedIn.Connector.DataLake.Common.Buffers;
 
+using Xunit;
+
 namespace CluedIn.Connector.DataLake.Common.Tests.Unit;
 
 public class LegacyBufferTests : BufferTestsBase
@@ -18,5 +20,68 @@ public class LegacyBufferTests : BufferTestsBase
             actionHistory.Add((DateTime.Now, x));
             return Task.CompletedTask;
         });
+    }
+
+    [Fact]
+    public async Task GetStatus_WhenEmpty_ReturnsZeroPendingItems()
+    {
+        // arrange
+        var idleTimeout = 5000;
+        var maxBatchSize = 5;
+        var actionHistory = new List<(DateTime actionAt, string[] items)>();
+        using var buffer = CreateBuffer(idleTimeout, maxBatchSize, actionHistory);
+
+        // act
+        var status = await buffer.GetStatus();
+
+        // assert
+        Assert.Equal(0, status.TotalPendingItems);
+        Assert.Equal(maxBatchSize, status.MaxPendingItems);
+        Assert.Equal(idleTimeout, status.TimeOutMilliseconds);
+        Assert.NotNull(status.AdditionalInformation);
+    }
+
+    [Fact]
+    public async Task GetStatus_AfterAddingItems_ReflectsPendingCount()
+    {
+        // arrange
+        var idleTimeout = 10000;
+        var maxBatchSize = 10;
+        var actionHistory = new List<(DateTime actionAt, string[] items)>();
+        using var buffer = CreateBuffer(idleTimeout, maxBatchSize, actionHistory);
+
+        // act
+        _ = buffer.Add("item1");
+        _ = buffer.Add("item2");
+        _ = buffer.Add("item3");
+        await Task.Delay(200); // allow adds to complete
+
+        var status = await buffer.GetStatus();
+
+        // assert
+        Assert.Equal(3, status.TotalPendingItems);
+        Assert.Equal(maxBatchSize, status.MaxPendingItems);
+        Assert.Equal(idleTimeout, status.TimeOutMilliseconds);
+    }
+
+    [Fact]
+    public async Task GetStatus_AfterFlush_ReturnsZeroPendingItems()
+    {
+        // arrange
+        var idleTimeout = 10000;
+        var maxBatchSize = 10;
+        var actionHistory = new List<(DateTime actionAt, string[] items)>();
+        using var buffer = CreateBuffer(idleTimeout, maxBatchSize, actionHistory);
+
+        // act
+        _ = buffer.Add("item1");
+        _ = buffer.Add("item2");
+        await Task.Delay(200);
+        await buffer.Flush();
+
+        var status = await buffer.GetStatus();
+
+        // assert
+        Assert.Equal(0, status.TotalPendingItems);
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: AB#
This branch adds two new connector actions to the Data Lake connectors and improves resource disposal:
1. Get Connector Version Action
Exposes a connector action that returns assembly version information for both the specific connector (e.g., Azure Data Lake, OneLake) and the common DataLakeConnector library, allowing operators to inspect deployed versions at runtime.
2. Get Buffer Status Action
Adds a connector action to query the in-memory buffer status across all peer instances. It works by:
•	Publishing a BufferStatusRequestedEvent via the system event bus.
•	Each peer responds with a BufferStatusRetrievedEvent containing its local buffer state (pending items, max capacity, timeout, and additional info).
•	Results are aggregated from all responding peers within a configurable timeout (capped at a maximum).
This required adding a GetStatus() method to the IBuffer<T> interface and implementing it in Buffer, ChannelBasedBuffer, SafeBuffer, and PartitionedBuffer. A new BufferStatus record was introduced to represent buffer state.
3. Improved Dispose Pattern
DataLakeConnector now implements the full IDisposable pattern (with Dispose(bool) and GC.SuppressFinalize), properly disposing both the buffer and the buffer-status event subscription.
4. Constructor Change
All concrete connector classes (AzureDataLake, OneLake, OpenMirroring, AzureDatabricks, AzureAIStudio, SynapseDataEngineering) were updated to pass ApplicationContext into the base DataLakeConnector constructor, enabling access to the system event bus for the buffer-status feature.
Supporting Changes
•	New unit tests in LegacyBufferTests.cs covering Buffer.GetStatus().
•	Integration test base classes updated with the new constructor parameter.


## How has it been tested? <!-- Remove if not needed -->


## Release Note <!-- Remove if not needed -->


## Notable Changes <!-- Remove if not needed -->
