### PR TITLE
feat: Prevent race condition causing inconsistent state

### DIFF
--- a/src/Connector.AzureAIStudio/AzureAIStudioJobDataFactory.cs
+++ b/src/Connector.AzureAIStudio/AzureAIStudioJobDataFactory.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using CluedIn.Connector.DataLake.Common;

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
@@ -27,9 +27,7 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         ExecutionContext executionContext,
         IReadOnlyStreamModel streamModel)
     {
-        var containerName = streamModel.ContainerName;
-        var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
-        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
         var action = new ConnectorAction(RunExportActionName, "Run Export", "Run export now", [], []);
         var streamRepository = executionContext.ApplicationContext.Container.Resolve<IStreamRepository>();
 
@@ -121,9 +119,8 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         ExecuteConnectorActionRequest request)
     {
         var startedAt = _dateTimeOffsetProvider.GetCurrentUtcTime();
-        var containerName = streamModel.ContainerName;
         var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
-        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
         await using var connection = new SqlConnection(configuration.StreamCacheConnectionString);
         await connection.OpenAsync();
         var streamId = streamModel.Id;
@@ -182,9 +179,8 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         ExecuteConnectorActionRequest request)
     {
         var startedAt = _dateTimeOffsetProvider.GetCurrentUtcTime();
-        var containerName = streamModel.ContainerName;
         var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
-        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
         await using var connection = new SqlConnection(configuration.StreamCacheConnectionString);
         await connection.OpenAsync();
         var streamId = streamModel.Id;
@@ -236,9 +232,8 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
         ExecuteConnectorActionRequest request)
     {
         var startedAt = _dateTimeOffsetProvider.GetCurrentUtcTime();
-        var containerName = streamModel.ContainerName;
         var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
-        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
         await using var connection = new SqlConnection(configuration.StreamCacheConnectionString);
         await connection.OpenAsync();
         var streamId = streamModel.Id;

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.ConnectorActions.cs
@@ -40,7 +40,7 @@ public abstract partial class DataLakeConnector : ICustomActionConnector
     private async Task ProcessBufferStatusRequestedEventAsync(BufferStatusRequestedEvent eventData)
     {
         await using var executionContext = _applicationContext.CreateExecutionContext(eventData.OrganizationId);
-        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, eventData.ProviderDefinitionId, eventData.ContainerName);
+        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, eventData.ProviderDefinitionId);
 
         if (_buffer.TryGet(configuration, out var buffer))
         {

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -145,7 +145,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             }
 
             var useSoftDelete = GetUseSoftDelete(jobData);
-            if (!data.ContainsKey(DataLakeConstants.ChangeTypeKey))
+            if (useSoftDelete && !data.ContainsKey(DataLakeConstants.ChangeTypeKey))
             {
                 AddToData(DataLakeConstants.ChangeTypeKey, connectorEntityData.ChangeType.ToString());
             }

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -144,7 +144,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 AddToData(DataLakeConstants.EpochKey, now.ToUnixTimeMilliseconds());
             }
 
-            var useSoftDelete = GetUseSoftDelete(jobData);
+            var useSoftDelete = GetUseSoftDelete(streamModel, jobData);
             if (useSoftDelete && !data.ContainsKey(DataLakeConstants.ChangeTypeKey))
             {
                 AddToData(DataLakeConstants.ChangeTypeKey, connectorEntityData.ChangeType.ToString());
@@ -178,8 +178,15 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             }
         }
 
-        private static bool GetUseSoftDelete(IDataLakeJobData jobData)
+        private static bool GetUseSoftDelete(
+            IReadOnlyStreamModel streamModel,
+            IDataLakeJobData jobData)
         {
+            if (streamModel.Mode != StreamMode.Sync || !jobData.IsStreamCacheEnabled)
+            {
+                return false;
+            }
+
             return jobData.IsDeltaMode || jobData.IsSoftDelete;
         }
 
@@ -250,7 +257,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 dataValueTypes);
             var tableName = GetCacheTableName(syncItem.StreamId);
 
-            var useSoftDelete = GetUseSoftDelete(configurations);
+            var useSoftDelete = GetUseSoftDelete(streamModel, configurations);
             try
             {
                 using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -144,6 +144,12 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 AddToData(DataLakeConstants.EpochKey, now.ToUnixTimeMilliseconds());
             }
 
+            var useSoftDelete = GetUseSoftDelete(jobData);
+            if (!data.ContainsKey(DataLakeConstants.ChangeTypeKey))
+            {
+                AddToData(DataLakeConstants.ChangeTypeKey, connectorEntityData.ChangeType.ToString());
+            }
+
             // end match previous version of the connector
             if (streamModel.ExportOutgoingEdges)
             {
@@ -158,10 +164,6 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             {
                 if (jobData.IsStreamCacheEnabled && streamModel.Mode == StreamMode.Sync)
                 {
-                    if (!data.ContainsKey(DataLakeConstants.ChangeTypeKey))
-                    {
-                        AddToData(DataLakeConstants.ChangeTypeKey, connectorEntityData.ChangeType.ToString());
-                    }
                     return await WriteToCacheTable(streamModel, connectorEntityData, jobData, data, dataValueTypes);
                 }
                 else
@@ -174,6 +176,11 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 _logger.LogError(ex, "Exception thrown. Returning SaveResult.ReQueue");
                 return SaveResult.ReQueue;
             }
+        }
+
+        private static bool GetUseSoftDelete(IDataLakeJobData jobData)
+        {
+            return jobData.IsDeltaMode || jobData.IsSoftDelete;
         }
 
         private static Type RemoveNullableType(Type type)
@@ -243,12 +250,13 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 dataValueTypes);
             var tableName = GetCacheTableName(syncItem.StreamId);
 
+            var useSoftDelete = GetUseSoftDelete(configurations);
             try
             {
                 using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
                 await using var connection = new SqlConnection(configurations.StreamCacheConnectionString);
                 await connection.OpenAsync();
-                await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: true);
+                await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: useSoftDelete);
                 transactionScope.Complete();
             }
             catch (SqlException writeDataException) when (writeDataException.IsTableNotFoundException())
@@ -269,7 +277,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     {
                         await EnsureCacheTableExists(connection, tableName, syncItem);
                     }
-                    await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: true);
+                    await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: useSoftDelete);
                     transactionScope.Complete();
                 }
                 catch (Exception ex2)
@@ -316,59 +324,13 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             }
             else
             {
-                // Prevent updates to removed records
-                // But allow recreation of removed records (e.g: Unmerge Deduplication)
-                var changeTypeConstraint = syncItem.ChangeType == VersionChangeType.Changed
-                    ? $"AND [{DataLakeConstants.ChangeTypeKey}] != '{VersionChangeType.Removed.ToString()}'"
-                    : string.Empty;
-
-                var insertOrUpdateSql = $"""
-                        IF EXISTS (
-                            SELECT 1 FROM [{tableName}] WITH (XLOCK, ROWLOCK)
-                            WHERE
-                                [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey})
-                        BEGIN
-                            UPDATE
-                                [{tableName}]
-                            SET
-                                {string.Join(",\n        ", propertyKeys.Select((key, index) => $"[{key}] = @p{index}"))}
-                            WHERE
-                                [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey} AND
-                                [{DataLakeConstants.PersistVersionKey}] < @EntityPersionVersion
-                              {changeTypeConstraint};
-                        END
-                        ELSE
-                        BEGIN
-                            INSERT INTO
-                                [{tableName}]
-                                ([{DataLakeConstants.IdKey}]{string.Join(string.Empty, propertyKeys.Select(key => $", [{key}]"))})
-                            VALUES(@{DataLakeConstants.IdKey}{string.Join(string.Empty, propertyKeys.Select((_, index) => $", @p{index}"))})
-                        END
-                        """;
-                var command = new SqlCommand(insertOrUpdateSql, connection)
+                if (useSoftDelete)
                 {
-                    CommandType = CommandType.Text
-                };
-                command.Parameters.Add(new SqlParameter($"@EntityPersionVersion", syncItem.PersistVersion));
-                command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
-
-                for (var i = 0; i < propertyKeys.Count; i++)
-                {
-                    var key = propertyKeys[i];
-                    command.Parameters.Add(new SqlParameter($"@p{i}", GetDatabaseValue(syncItem, key)));
+                    await InsertWithSoftDelete();
                 }
-
-                var rowsAffected = await command.ExecuteNonQueryAsync();
-                if (rowsAffected != 1)
+                else
                 {
-                    // check if row exists to determine if failure was due to update condition not being met or some other issue
-                    if (rowsAffected == 0)
-                    {
-                        await VerifyRowUpToDate(connection, syncItem, tableName);
-                        return;
-                    }
-
-                    throw new ApplicationException($"Rows affected for upsert of is not 1, it is {rowsAffected} for item {syncItem.EntityId}.");
+                    await InsertWithHardDelete();
                 }
             }
 
@@ -456,6 +418,104 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     persistVersion < syncItem.PersistVersion)
                 {
                     throw new ApplicationException($"Unable to update cache table item {syncItem.EntityId} from PersistVersion '{persistVersion}' to '{syncItem.PersistVersion}'.");
+                }
+            }
+
+            async Task InsertWithSoftDelete()
+            {
+                // Prevent updates to removed records
+                // But allow recreation of removed records (e.g: Unmerge Deduplication)
+                var changeTypeConstraint = syncItem.ChangeType == VersionChangeType.Changed
+                    ? $"AND [{DataLakeConstants.ChangeTypeKey}] != '{VersionChangeType.Removed.ToString()}'"
+                    : string.Empty;
+
+                var insertOrUpdateSql = $"""
+                                         IF EXISTS (
+                                             SELECT 1 FROM [{tableName}] WITH (XLOCK, ROWLOCK)
+                                             WHERE
+                                                 [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey})
+                                         BEGIN
+                                             UPDATE
+                                                 [{tableName}]
+                                             SET
+                                                 {string.Join(",\n        ", propertyKeys.Select((key, index) => $"[{key}] = @p{index}"))}
+                                             WHERE
+                                                 [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey} AND
+                                                 [{DataLakeConstants.PersistVersionKey}] < @EntityPersionVersion
+                                               {changeTypeConstraint};
+                                         END
+                                         ELSE
+                                         BEGIN
+                                             INSERT INTO
+                                                 [{tableName}]
+                                                 ([{DataLakeConstants.IdKey}]{string.Join(string.Empty, propertyKeys.Select(key => $", [{key}]"))})
+                                             VALUES(@{DataLakeConstants.IdKey}{string.Join(string.Empty, propertyKeys.Select((_, index) => $", @p{index}"))})
+                                         END
+                                         """;
+                var command = new SqlCommand(insertOrUpdateSql, connection)
+                {
+                    CommandType = CommandType.Text
+                };
+                command.Parameters.Add(new SqlParameter($"@EntityPersionVersion", syncItem.PersistVersion));
+                command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
+
+                for (var i = 0; i < propertyKeys.Count; i++)
+                {
+                    var key = propertyKeys[i];
+                    command.Parameters.Add(new SqlParameter($"@p{i}", GetDatabaseValue(syncItem, key)));
+                }
+
+                var rowsAffected = await command.ExecuteNonQueryAsync();
+                if (rowsAffected != 1)
+                {
+                    // check if row exists to determine if failure was due to update condition not being met or some other issue
+                    if (rowsAffected == 0)
+                    {
+                        await VerifyRowUpToDate(connection, syncItem, tableName);
+                        return;
+                    }
+
+                    throw new ApplicationException($"Rows affected for upsert of is not 1, it is {rowsAffected} for item {syncItem.EntityId}.");
+                }
+            }
+
+            async Task InsertWithHardDelete()
+            {
+                var insertOrUpdateSql = $"""
+                                         IF EXISTS (
+                                             SELECT 1 FROM [{tableName}] WITH (XLOCK, ROWLOCK)
+                                             WHERE {DataLakeConstants.IdKey} = @{DataLakeConstants.IdKey})
+                                         BEGIN
+                                             UPDATE
+                                                [{tableName}]
+                                             SET
+                                                 {string.Join(",\n        ", propertyKeys.Select((key, index) => $"[{key}] = @p{index}"))}
+                                             WHERE [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey};
+                                         END
+                                         ELSE
+                                         BEGIN
+                                             INSERT INTO
+                                                [{tableName}]
+                                                ([{DataLakeConstants.IdKey}]{string.Join(string.Empty, propertyKeys.Select(key => $", [{key}]"))})
+                                             VALUES(@{DataLakeConstants.IdKey}{string.Join(string.Empty, propertyKeys.Select((_, index) => $", @p{index}"))})
+                                         END
+                                         """;
+                var command = new SqlCommand(insertOrUpdateSql, connection)
+                {
+                    CommandType = CommandType.Text
+                };
+                command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
+
+                for (var i = 0; i < propertyKeys.Count; i++)
+                {
+                    var key = propertyKeys[i];
+                    command.Parameters.Add(new SqlParameter($"@p{i}", GetDatabaseValue(syncItem, key)));
+                }
+
+                var rowsAffected = await command.ExecuteNonQueryAsync();
+                if (rowsAffected != 1)
+                {
+                    throw new ApplicationException($"Rows affected for insertion of is not 1, it is {rowsAffected}.");
                 }
             }
         }

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -425,8 +425,9 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             {
                 // Prevent updates to removed records
                 // But allow recreation of removed records (e.g: Unmerge Deduplication)
+                // We have to cater for DataLakeConstants.ChangeTypeKey being NULL because of migration. Migrated tables have that field set to NULL
                 var changeTypeConstraint = syncItem.ChangeType == VersionChangeType.Changed
-                    ? $"AND [{DataLakeConstants.ChangeTypeKey}] != '{VersionChangeType.Removed.ToString()}'"
+                    ? $"AND ([{DataLakeConstants.ChangeTypeKey}] != '{nameof(VersionChangeType.Removed)}' OR [{DataLakeConstants.ChangeTypeKey}] IS NULL)"
                     : string.Empty;
 
                 var insertOrUpdateSql = $"""
@@ -442,7 +443,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                                              WHERE
                                                  [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey} AND
                                                  [{DataLakeConstants.PersistVersionKey}] < @EntityPersionVersion
-                                               {changeTypeConstraint};
+                                                {changeTypeConstraint};
                                          END
                                          ELSE
                                          BEGIN

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -104,7 +104,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         {
             var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
             var containerName = streamModel.ContainerName;
-            var jobData = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+            var jobData = await _dataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
 
             // matching output format of previous version of the connector
             var data = connectorEntityData.Properties.ToDictionary(property => property.Name, property => property.Value);
@@ -808,7 +808,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         {
             _logger.LogInformation($"DataLakeConnector.GetContainers: entry");
 
-            var jobData = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, "");
+            var jobData = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId);
 
             return await _client.GetFilesInDirectory(jobData);
         }
@@ -852,10 +852,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
 
         private async Task RenameCacheTableIfExists(ExecutionContext executionContext, IReadOnlyStreamModel streamModel)
         {
-            var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
-            var containerName = streamModel.ContainerName;
-
-            var jobData = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+            var jobData = await _dataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
             if (string.IsNullOrWhiteSpace(jobData.StreamCacheConnectionString))
             {
                 _logger.LogDebug("Skipping renaming of cache table because stream cache connection string is null or whitespace.");

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -451,7 +451,9 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     throw new ApplicationException($"Unable to parse change type '{changeType}' from the cache table item {syncItem.EntityId}.");
                 }
 
-                if (parsedChangedType != VersionChangeType.Removed && persistVersion < syncItem.PersistVersion)
+                if (parsedChangedType != VersionChangeType.Removed &&
+                    syncItem.PersistVersion != null &&
+                    persistVersion < syncItem.PersistVersion)
                 {
                     throw new ApplicationException($"Unable to update cache table item {syncItem.EntityId} from PersistVersion '{persistVersion}' to '{syncItem.PersistVersion}'.");
                 }

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -125,7 +125,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
 
             AddToData(DataLakeConstants.IdKey, connectorEntityData.EntityId);
             AddToData("PersistHash", connectorEntityData.PersistInfo?.PersistHash);
-            AddToData("PersistVersion", connectorEntityData.PersistInfo?.PersistVersion);
+            AddToData(DataLakeConstants.PersistVersionKey, connectorEntityData.PersistInfo?.PersistVersion);
             AddToData("OriginEntityCode", connectorEntityData.OriginEntityCode?.ToString());
             AddToData("EntityType", connectorEntityData.EntityType?.ToString());
             AddToData("Codes", connectorEntityData.EntityCodes.SafeEnumerate().Select(code => code.ToString()));
@@ -134,19 +134,14 @@ namespace CluedIn.Connector.DataLake.Common.Connector
 
             var now = _dateTimeOffsetProvider.GetCurrentUtcTime();
 
-            if (!data.ContainsKey("Timestamp"))
+            if (!data.ContainsKey(DataLakeConstants.TimestampKey))
             {
-                AddToData("Timestamp", now.ToString("O"));
+                AddToData(DataLakeConstants.TimestampKey, now.ToString("O"));
             }
 
-            if (!data.ContainsKey("Epoch"))
+            if (!data.ContainsKey(DataLakeConstants.EpochKey))
             {
-                AddToData("Epoch", now.ToUnixTimeMilliseconds());
-            }
-
-            if (jobData.IsDeltaMode && !data.ContainsKey(DataLakeConstants.ChangeTypeKey))
-            {
-                AddToData(DataLakeConstants.ChangeTypeKey, connectorEntityData.ChangeType.ToString());
+                AddToData(DataLakeConstants.EpochKey, now.ToUnixTimeMilliseconds());
             }
 
             // end match previous version of the connector
@@ -163,6 +158,10 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             {
                 if (jobData.IsStreamCacheEnabled && streamModel.Mode == StreamMode.Sync)
                 {
+                    if (!data.ContainsKey(DataLakeConstants.ChangeTypeKey))
+                    {
+                        AddToData(DataLakeConstants.ChangeTypeKey, connectorEntityData.ChangeType.ToString());
+                    }
                     return await WriteToCacheTable(streamModel, connectorEntityData, jobData, data, dataValueTypes);
                 }
                 else
@@ -204,12 +203,12 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 IF NOT EXISTS (SELECT * FROM SYSOBJECTS WHERE NAME='{tableName}' AND XTYPE='U')
                 BEGIN
                     CREATE TABLE [{tableName}] (
-                        {DataLakeConstants.IdKey} UNIQUEIDENTIFIER NOT NULL,
+                        [{DataLakeConstants.IdKey}] UNIQUEIDENTIFIER NOT NULL,
                         {string.Join(string.Empty, propertiesColumns.Select(prop => $"{prop},\n    "))}
                         [ValidFrom] DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN,
                         [ValidTo] DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN,
                         PERIOD FOR SYSTEM_TIME(ValidFrom, ValidTo),
-                        CONSTRAINT [PK_{tableName}] PRIMARY KEY CLUSTERED ({DataLakeConstants.IdKey})
+                        CONSTRAINT [PK_{tableName}] PRIMARY KEY CLUSTERED ([{DataLakeConstants.IdKey}])
                     ) WITH (SYSTEM_VERSIONING = ON (HISTORY_TABLE = dbo.[{tableName}_History]));
                     CREATE INDEX [ValidFromValidTo] ON [{tableName}] ([ValidFrom], [ValidTo]);
                 END
@@ -235,7 +234,13 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 return SaveResult.Failed;
             }
 
-            var syncItem = new SyncItem(streamModel.Id, connectorEntityData.EntityId, connectorEntityData.ChangeType, data, dataValueTypes);
+            var syncItem = new SyncItem(
+                streamModel.Id,
+                connectorEntityData.EntityId,
+                connectorEntityData.PersistInfo?.PersistVersion,
+                connectorEntityData.ChangeType,
+                data,
+                dataValueTypes);
             var tableName = GetCacheTableName(syncItem.StreamId);
 
             try
@@ -243,7 +248,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 using var transactionScope = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled);
                 await using var connection = new SqlConnection(configurations.StreamCacheConnectionString);
                 await connection.OpenAsync();
-                await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: configurations.IsDeltaMode);
+                await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: true);
                 transactionScope.Complete();
             }
             catch (SqlException writeDataException) when (writeDataException.IsTableNotFoundException())
@@ -264,7 +269,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     {
                         await EnsureCacheTableExists(connection, tableName, syncItem);
                     }
-                    await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: configurations.IsDeltaMode);
+                    await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: true);
                     transactionScope.Complete();
                 }
                 catch (Exception ex2)
@@ -311,19 +316,32 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             }
             else
             {
+                // Prevent updates to removed records
+                // But allow recreation of removed records (e.g: Unmerge Deduplication)
+                var changeTypeConstraint = syncItem.ChangeType == VersionChangeType.Changed
+                    ? $"AND [{DataLakeConstants.ChangeTypeKey}] != '{VersionChangeType.Removed.ToString()}'"
+                    : string.Empty;
+
                 var insertOrUpdateSql = $"""
                         IF EXISTS (
                             SELECT 1 FROM [{tableName}] WITH (XLOCK, ROWLOCK)
-                            WHERE {DataLakeConstants.IdKey} = @{DataLakeConstants.IdKey})
+                            WHERE
+                                [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey})
                         BEGIN
-                            UPDATE [{tableName}]
+                            UPDATE
+                                [{tableName}]
                             SET
                                 {string.Join(",\n        ", propertyKeys.Select((key, index) => $"[{key}] = @p{index}"))}
-                            WHERE {DataLakeConstants.IdKey} = @{DataLakeConstants.IdKey};
+                            WHERE
+                                [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey} AND
+                                [{DataLakeConstants.PersistVersionKey}] < @EntityPersionVersion
+                              {changeTypeConstraint};
                         END
                         ELSE
                         BEGIN
-                            INSERT INTO [{tableName}] ({DataLakeConstants.IdKey}{string.Join(string.Empty, propertyKeys.Select(key => $", [{key}]"))})
+                            INSERT INTO
+                                [{tableName}]
+                                ([{DataLakeConstants.IdKey}]{string.Join(string.Empty, propertyKeys.Select(key => $", [{key}]"))})
                             VALUES(@{DataLakeConstants.IdKey}{string.Join(string.Empty, propertyKeys.Select((_, index) => $", @p{index}"))})
                         END
                         """;
@@ -331,6 +349,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 {
                     CommandType = CommandType.Text
                 };
+                command.Parameters.Add(new SqlParameter($"@EntityPersionVersion", syncItem.PersistVersion));
                 command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
 
                 for (var i = 0; i < propertyKeys.Count; i++)
@@ -342,7 +361,14 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 var rowsAffected = await command.ExecuteNonQueryAsync();
                 if (rowsAffected != 1)
                 {
-                    throw new ApplicationException($"Rows affected for insertion of is not 1, it is {rowsAffected}.");
+                    // check if row exists to determine if failure was due to update condition not being met or some other issue
+                    if (rowsAffected == 0)
+                    {
+                        await VerifyRowUpToDate(connection, syncItem, tableName);
+                        return;
+                    }
+
+                    throw new ApplicationException($"Rows affected for upsert of is not 1, it is {rowsAffected} for item {syncItem.EntityId}.");
                 }
             }
 
@@ -366,14 +392,14 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 var updateSql = $"""
                         IF EXISTS (
                             SELECT 1 FROM [{tableName}] WITH (XLOCK, ROWLOCK)
-                            WHERE {DataLakeConstants.IdKey} = @{DataLakeConstants.IdKey})
+                            WHERE [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey})
                         BEGIN
                             UPDATE [{tableName}]
                             SET
-                                [{DataLakeConstants.ChangeTypeKey}] = @ChangeType,
-                                [Timestamp] = @Timestamp,
-                                [Epoch] = @Epoch
-                            WHERE {DataLakeConstants.IdKey} = @{DataLakeConstants.IdKey};
+                                [{DataLakeConstants.ChangeTypeKey}] = @{DataLakeConstants.ChangeTypeKey},
+                                [{DataLakeConstants.TimestampKey}] = @{DataLakeConstants.TimestampKey},
+                                [{DataLakeConstants.EpochKey}] = @{DataLakeConstants.EpochKey}
+                            WHERE [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey};
                         END
                         """;
                 var command = new SqlCommand(updateSql, connection)
@@ -381,14 +407,53 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     CommandType = CommandType.Text
                 };
                 command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
-                command.Parameters.Add(new SqlParameter($"@ChangeType", syncItem.ChangeType.ToString()));
-                command.Parameters.Add(new SqlParameter($"@Timestamp", syncItem.Data["Timestamp"]));
-                command.Parameters.Add(new SqlParameter($"@Epoch", syncItem.Data["Epoch"]));
+                command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.ChangeTypeKey}", syncItem.ChangeType.ToString()));
+                command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.TimestampKey}", syncItem.Data[DataLakeConstants.TimestampKey]));
+                command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.EpochKey}", syncItem.Data[DataLakeConstants.EpochKey]));
 
                 var rowsAffected = await command.ExecuteNonQueryAsync();
                 if (rowsAffected != 1)
                 {
                     throw new ApplicationException($"Rows affected for soft deletion of is not 1, it is {rowsAffected}.");
+                }
+            }
+
+            static async Task VerifyRowUpToDate(SqlConnection connection, SyncItem syncItem, string tableName)
+            {
+                var getVersionSql = $"""
+                            SELECT
+                                [{DataLakeConstants.IdKey}],
+                                [{DataLakeConstants.PersistVersionKey}],
+                                [{DataLakeConstants.ChangeTypeKey}]
+                            FROM
+                                [{tableName}]
+                            WITH
+                                (XLOCK, ROWLOCK)
+                            WHERE
+                                [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey};
+                            """;
+                var getVersionCommand = new SqlCommand(getVersionSql, connection)
+                {
+                    CommandType = CommandType.Text
+                };
+                getVersionCommand.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
+                await using var getVersionReader = await getVersionCommand.ExecuteReaderAsync();
+                if (!await getVersionReader.ReadAsync())
+                {
+                    throw new ApplicationException($"No rows updated for upsert and entity could not be found.");
+                }
+
+                var changeType = getVersionReader.GetValue(DataLakeConstants.ChangeTypeKey).ToString();
+                var persistVersion = Convert.ToInt32(getVersionReader.GetValue(DataLakeConstants.PersistVersionKey));
+
+                if (!Enum.TryParse<VersionChangeType>(changeType, out var parsedChangedType))
+                {
+                    throw new ApplicationException($"Unable to parse change type '{changeType}' from the cache table item {syncItem.EntityId}.");
+                }
+
+                if (parsedChangedType != VersionChangeType.Removed && persistVersion < syncItem.PersistVersion)
+                {
+                    throw new ApplicationException($"Unable to update cache table item {syncItem.EntityId} from PersistVersion '{persistVersion}' to '{syncItem.PersistVersion}'.");
                 }
             }
         }
@@ -574,15 +639,24 @@ namespace CluedIn.Connector.DataLake.Common.Connector
             var testTableName = GetCacheTableName(testStreamId, true);
 
             var entityId = Guid.NewGuid();
+            var now = _dateTimeOffsetProvider.GetCurrentUtcTime();
             var data = new Dictionary<string, object>
             {
                 [DataLakeConstants.IdKey] = entityId,
+                [DataLakeConstants.ChangeTypeKey] = VersionChangeType.Added.ToString(),
+                [DataLakeConstants.PersistVersionKey] = 1,
+                [DataLakeConstants.TimestampKey] = now,
+                [DataLakeConstants.EpochKey] = now.ToUnixTimeMilliseconds(),
                 ["testColumn"] = 1234,
             };
 
             var dataValueTypes = new Dictionary<string, Type>
             {
                 [DataLakeConstants.IdKey] = typeof(Guid),
+                [DataLakeConstants.ChangeTypeKey] = typeof(string),
+                [DataLakeConstants.PersistVersionKey] = typeof(int),
+                [DataLakeConstants.TimestampKey] = typeof(DateTimeOffset),
+                [DataLakeConstants.EpochKey] = typeof(long),
                 ["testColumn"] = typeof(string),
             };
 
@@ -597,12 +671,13 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                     throw new ApplicationException("Failed to acquire lock for verifying connection.");
                 }
 
-                var baseSyncItem = new SyncItem(testStreamId, entityId, VersionChangeType.Added, data, dataValueTypes);
+                var baseSyncItem = new SyncItem(testStreamId, entityId, PersistVersion: 1, VersionChangeType.Added, data, dataValueTypes);
                 await EnsureCacheTableExists(
                         connection,
                         testTableName,
                         baseSyncItem);
                 await VerifyOperation(connection, testTableName, baseSyncItem);
+
                 await VerifyOperation(connection, testTableName, baseSyncItem with { ChangeType = VersionChangeType.Changed });
                 await VerifyOperation(connection, testTableName, baseSyncItem with { ChangeType = VersionChangeType.Removed });
                 await RenameCacheTableIfExists(connection, testTableName);
@@ -618,7 +693,12 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         {
             try
             {
-                await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: false);
+                var now = _dateTimeOffsetProvider.GetCurrentUtcTime();
+                syncItem.Data[DataLakeConstants.ChangeTypeKey] = syncItem.ChangeType.ToString();
+                syncItem.Data[DataLakeConstants.PersistVersionKey] = syncItem.PersistVersion;
+                syncItem.Data[DataLakeConstants.TimestampKey] = now;
+                syncItem.Data[DataLakeConstants.EpochKey] = now.ToUnixTimeMilliseconds();
+                await WriteToCacheTable(connection, syncItem, tableName, useSoftDelete: true);
 
             }
             catch (Exception ex)
@@ -792,6 +872,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         private record SyncItem(
             Guid StreamId,
             Guid EntityId,
+            int? PersistVersion,
             VersionChangeType ChangeType,
             IDictionary<string, object> Data,
             Dictionary<string, Type> DataValueTypes);

--- a/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeConnector.cs
@@ -449,7 +449,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                                                  {string.Join(",\n        ", propertyKeys.Select((key, index) => $"[{key}] = @p{index}"))}
                                              WHERE
                                                  [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey} AND
-                                                 [{DataLakeConstants.PersistVersionKey}] < @EntityPersionVersion
+                                                 [{DataLakeConstants.PersistVersionKey}] < @EntityPersistVersion
                                                 {changeTypeConstraint};
                                          END
                                          ELSE
@@ -464,7 +464,7 @@ namespace CluedIn.Connector.DataLake.Common.Connector
                 {
                     CommandType = CommandType.Text
                 };
-                command.Parameters.Add(new SqlParameter($"@EntityPersionVersion", syncItem.PersistVersion));
+                command.Parameters.Add(new SqlParameter($"@EntityPersistVersion", syncItem.PersistVersion));
                 command.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", syncItem.EntityId));
 
                 for (var i = 0; i < propertyKeys.Count; i++)

--- a/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
@@ -144,6 +144,7 @@ internal abstract class DataLakeExportEntitiesJobBase : DataLakeJobBase
         {
             CommandType = CommandType.Text
         };
+
         if (shouldProduceDelta)
         {
             command.Parameters.Add(new SqlParameter("@ValidFrom", LastExport.DataTime));

--- a/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeExportEntitiesJobBase.cs
@@ -367,7 +367,7 @@ internal abstract class DataLakeExportEntitiesJobBase : DataLakeJobBase
         var containerName = streamModel.ContainerName;
         var executionContext = context.ApplicationContext.CreateExecutionContext(streamModel.OrganizationId);
 
-        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+        var configuration = await _dataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
 
         if (!configuration.IsStreamCacheEnabled)
         {

--- a/src/Connector.DataLake.Common/Connector/SqlDataWriter/SqlDataWriterBase.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlDataWriter/SqlDataWriterBase.cs
@@ -68,11 +68,16 @@ internal abstract class SqlDataWriterBase : ISqlDataWriter
             return isInitialExport && IsRowRemoved(reader);
         }
 
+        if (!configuration.IsSoftDelete)
+        {
+            return false;
+        }
+
         return IsRowRemoved(reader);
 
         static bool IsRowRemoved(SqlDataReader reader)
         {
-            return GetValueInternal(DataLakeConstants.ChangeTypeKey, reader).Equals(VersionChangeType.Removed.ToString());
+            return nameof(VersionChangeType.Removed).Equals(GetValueInternal(DataLakeConstants.ChangeTypeKey, reader));
         }
     }
 }

--- a/src/Connector.DataLake.Common/Connector/SqlDataWriter/SqlDataWriterBase.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlDataWriter/SqlDataWriterBase.cs
@@ -63,8 +63,16 @@ internal abstract class SqlDataWriterBase : ISqlDataWriter
 
     protected virtual bool ShouldSkip(IDataLakeJobData configuration, bool isInitialExport, SqlDataReader reader)
     {
-        return configuration.IsDeltaMode
-            && isInitialExport
-            && GetValueInternal(DataLakeConstants.ChangeTypeKey, reader).Equals(VersionChangeType.Removed.ToString());
+        if (configuration.IsDeltaMode)
+        {
+            return isInitialExport && IsRowRemoved(reader);
+        }
+
+        return IsRowRemoved(reader);
+
+        static bool IsRowRemoved(SqlDataReader reader)
+        {
+            return GetValueInternal(DataLakeConstants.ChangeTypeKey, reader).Equals(VersionChangeType.Removed.ToString());
+        }
     }
 }

--- a/src/Connector.DataLake.Common/Connector/SqlExceptionExtensions.cs
+++ b/src/Connector.DataLake.Common/Connector/SqlExceptionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace CluedIn.Connector.DataLake.Common.Connector;
 
@@ -7,5 +7,15 @@ internal static class SqlExceptionExtensions
     public static bool IsTableNotFoundException(this SqlException ex)
     {
         return ex?.Number == 208;
+    }
+
+    public static bool IsCannotFindTableException(this SqlException ex)
+    {
+        return ex?.Number == 4902;
+    }
+
+    public static bool IsColumnAlreadyExistsException(this SqlException ex)
+    {
+        return ex?.Number == 2705;
     }
 }

--- a/src/Connector.DataLake.Common/DataLakeConstants.cs
+++ b/src/Connector.DataLake.Common/DataLakeConstants.cs
@@ -26,6 +26,7 @@ public abstract class DataLakeConstants : ConfigurationConstantsBase, IDataLakeC
     public const string ShouldEscapeVocabularyKeys = nameof(ShouldEscapeVocabularyKeys);
     public const string CustomCron = nameof(CustomCron);
     public const string IsDeltaMode = nameof(IsDeltaMode);
+    public const string IsSoftDelete = nameof(IsSoftDelete);
     public const string IsOverwriteEnabled = nameof(IsOverwriteEnabled);
     public const string IsArrayColumnsEnabled = nameof(IsArrayColumnsEnabled);
 

--- a/src/Connector.DataLake.Common/DataLakeConstants.cs
+++ b/src/Connector.DataLake.Common/DataLakeConstants.cs
@@ -11,6 +11,9 @@ public abstract class DataLakeConstants : ConfigurationConstantsBase, IDataLakeC
 {
     internal const string ProviderDefinitionIdKey = "__ProviderDefinitionId__";
     internal const string ChangeTypeKey = "__ChangeType__";
+    internal const string PersistVersionKey = "PersistVersion";
+    internal const string TimestampKey = "Timestamp";
+    internal const string EpochKey = "Epoch";
 
     public const string ContainerName = nameof(ContainerName);
     public const string OutputFormat = nameof(OutputFormat);

--- a/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
@@ -1,12 +1,11 @@
 using System;
-using System.Reflection;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using CluedIn.Core;
-using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Relational;
-using CluedIn.Core.DataStore;
 using CluedIn.Core.DataStore.Entities;
+using CluedIn.Core.Streams;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -17,6 +16,7 @@ internal class DataLakeDataMigrator : DataMigrator
 {
     protected readonly IDataLakeConstants _dataLakeConstants;
     protected readonly IDataLakeJobDataFactory _dataLakeJobDataFactory;
+    private const int StreamsPerPage = 100;
 
     public DataLakeDataMigrator(
         ILogger logger,
@@ -77,7 +77,6 @@ internal class DataLakeDataMigrator : DataMigrator
         await MigrateForOrganizations("SoftDeleteDefault", MigrateSoftDeleteForProviderDefinition);
         async Task MigrateSoftDeleteForProviderDefinition(ExecutionContext context, string componentMigrationName)
         {
-            var invalidCacheMethod = typeof(AuthenticationDetailsHelper).GetMethod("InvalidateCacheAsync", [typeof(ApplicationContext), typeof(Guid)]);
             var organizationId = context.Organization.Id;
             var store = context.Organization.DataStores.GetDataStore<ProviderDefinition>();
             var definitions = await store.SelectAsync(
@@ -86,54 +85,34 @@ internal class DataLakeDataMigrator : DataMigrator
                                 && definition.ProviderId == _dataLakeConstants.ProviderId);
             foreach (var definition in definitions)
             {
-                if (definition.AccountId != string.Empty)
-                {
-                    _logger.LogDebug("Skipping provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
-                        componentMigrationName,
-                        organizationId,
-                        definition.Id);
-                    continue;
-                }
-
                 _logger.LogInformation("Begin provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
                     componentMigrationName,
                     organizationId,
                     definition.Id);
-                var configurationRepository = context.ApplicationContext.Container.Resolve<IConfigurationRepository>();
-                var configuration = configurationRepository.GetConfigurationById(context, definition.Id);
-                if (configuration == null)
+                var streamRepository = _applicationContext.Container.Resolve<IStreamRepository>();
+                var streamsCount = await streamRepository.GetOrganizationStreamsCount(context, filterConnectorProviderDefinitionId: definition.Id);
+                var streamsPerPage = StreamsPerPage;
+                var totalPages = (streamsCount + streamsPerPage - 1) / streamsPerPage;
+
+                for (var i = 0; i < totalPages; ++i)
                 {
-                    _logger.LogWarning("Configuration not found for ProviderDefinition '{ProviderDefinitionId}' during migration: '{MigrationName}' for organization '{OrganizationId}'. Skipping.",
-                        definition.Id,
-                        componentMigrationName,
-                        organizationId);
-                    continue;
+                    var streams = await streamRepository.GetOrganizationStreams(context, i, streamsPerPage, filterConnectorProviderDefinitionId: definition.Id);
+                    foreach (var stream in streams)
+                    {
+                        var connectorProperties = stream.ConnectorProperties == null ? new Dictionary<string, object>() : new Dictionary<string, object>(stream.ConnectorProperties);
+                        connectorProperties.TryAdd(
+                            DataLakeConstants.IsSoftDelete,
+                            false);
+
+                        await streamRepository.UpdateStream(context, stream.Id, stream, context.Organization.Id, stream.ModifiedBy);
+                    }
                 }
-                configuration[nameof(DataLakeConstants.IsSoftDelete)] = false;
-                configurationRepository.UpdateConfiguration(context, definition.Id, configuration);
-                if (invalidCacheMethod == null)
-                {
-                    _logger.LogWarning("InvalidateCacheAsync method not found on AuthenticationDetailsHelper. Cache will not be cleared for ProviderDefinition '{ProviderDefinitionId}' during migration.",
-                        definition.Id);
-                }
-                ClearConfigurationCache(context, definition.Id, invalidCacheMethod);
+
                 _logger.LogInformation("End provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
                     componentMigrationName,
                     organizationId,
                     definition.Id);
             }
-        }
-    }
-
-    private async Task ClearConfigurationCache(
-        ExecutionContext context,
-        Guid definitionId,
-        MethodInfo invalidCacheMethod)
-    {
-        var returnValue = (Task)invalidCacheMethod.Invoke(null, [context.ApplicationContext, definitionId]);
-        if (returnValue != null)
-        {
-            await returnValue;
         }
     }
 }

--- a/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
@@ -122,6 +122,7 @@ internal class DataLakeDataMigrator : DataMigrator
                 {
                     _logger.LogInformation("Stream cache is not enabled for ProviderDefinition '{ProviderDefinitionId}'. Skipping stream migration for soft delete.",
                         definition.Id);
+                    continue;
                 }
 
                 foreach (var stream in streams)

--- a/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
@@ -1,8 +1,11 @@
-﻿using System;
+using System;
+using System.Reflection;
 using System.Threading.Tasks;
 
 using CluedIn.Core;
+using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Relational;
+using CluedIn.Core.DataStore;
 using CluedIn.Core.DataStore.Entities;
 
 using Microsoft.EntityFrameworkCore;
@@ -30,6 +33,7 @@ internal class DataLakeDataMigrator : DataMigrator
     protected override async Task RunMigrations()
     {
         await MigrateAccountId();
+        await MigrateSoftDelete();
     }
 
     protected virtual async Task MigrateAccountId()
@@ -65,6 +69,71 @@ internal class DataLakeDataMigrator : DataMigrator
                     organizationId,
                     definition.Id);
             }
+        }
+    }
+
+    protected virtual async Task MigrateSoftDelete()
+    {
+        await MigrateForOrganizations("SoftDeleteDefault", MigrateSoftDeleteForProviderDefinition);
+        async Task MigrateSoftDeleteForProviderDefinition(ExecutionContext context, string componentMigrationName)
+        {
+            var invalidCacheMethod = typeof(AuthenticationDetailsHelper).GetMethod("InvalidateCacheAsync", [typeof(ApplicationContext), typeof(Guid)]);
+            var organizationId = context.Organization.Id;
+            var store = context.Organization.DataStores.GetDataStore<ProviderDefinition>();
+            var definitions = await store.SelectAsync(
+                context,
+                definition => definition.OrganizationId == context.Organization.Id
+                                && definition.ProviderId == _dataLakeConstants.ProviderId);
+            foreach (var definition in definitions)
+            {
+                if (definition.AccountId != string.Empty)
+                {
+                    _logger.LogDebug("Skipping provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
+                        componentMigrationName,
+                        organizationId,
+                        definition.Id);
+                    continue;
+                }
+
+                _logger.LogInformation("Begin provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
+                    componentMigrationName,
+                    organizationId,
+                    definition.Id);
+                var configurationRepository = context.ApplicationContext.Container.Resolve<IConfigurationRepository>();
+                var configuration = configurationRepository.GetConfigurationById(context, definition.Id);
+                if (configuration == null)
+                {
+                    _logger.LogWarning("Configuration not found for ProviderDefinition '{ProviderDefinitionId}' during migration: '{MigrationName}' for organization '{OrganizationId}'. Skipping.",
+                        definition.Id,
+                        componentMigrationName,
+                        organizationId);
+                    continue;
+                }
+                configuration[nameof(DataLakeConstants.IsSoftDelete)] = false;
+                configurationRepository.UpdateConfiguration(context, definition.Id, configuration);
+                if (invalidCacheMethod == null)
+                {
+                    _logger.LogWarning("InvalidateCacheAsync method not found on AuthenticationDetailsHelper. Cache will not be cleared for ProviderDefinition '{ProviderDefinitionId}' during migration.",
+                        definition.Id);
+                }
+                ClearConfigurationCache(context, definition.Id, invalidCacheMethod);
+                _logger.LogInformation("End provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
+                    componentMigrationName,
+                    organizationId,
+                    definition.Id);
+            }
+        }
+    }
+
+    private async Task ClearConfigurationCache(
+        ExecutionContext context,
+        Guid definitionId,
+        MethodInfo invalidCacheMethod)
+    {
+        var returnValue = (Task)invalidCacheMethod.Invoke(null, [context.ApplicationContext, definitionId]);
+        if (returnValue != null)
+        {
+            await returnValue;
         }
     }
 }

--- a/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
@@ -1,15 +1,19 @@
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 
+using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Core;
 using CluedIn.Core.Data.Relational;
+using CluedIn.Core.DataStore;
 using CluedIn.Core.DataStore.Entities;
 using CluedIn.Core.Events;
 using CluedIn.Core.Streams;
 using CluedIn.Core.Streams.Models;
 
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -20,7 +24,6 @@ internal class DataLakeDataMigrator : DataMigrator
     private readonly DbContextOptions<CluedInEntities> _cluedInEntitiesDbContextOptions;
     protected readonly IDataLakeConstants _dataLakeConstants;
     protected readonly IDataLakeJobDataFactory _dataLakeJobDataFactory;
-    private const int StreamsPerPage = 100;
 
     public DataLakeDataMigrator(
         ILogger logger,
@@ -90,6 +93,18 @@ internal class DataLakeDataMigrator : DataMigrator
                 definition => definition.OrganizationId == context.Organization.Id
                                 && definition.ProviderId == _dataLakeConstants.ProviderId);
 
+            var connectionStrings = context.ApplicationContext.System.ConnectionStrings;
+            var connectionStringKey = DataLakeConstants.StreamCacheConnectionStringKey;
+            var configurationKey = DataLakeConstants.StreamCacheConnectionString;
+            if (!connectionStrings.ConnectionStringExists(connectionStringKey))
+            {
+                throw new InvalidOperationException("Stream cache connection string is not found.");
+            }
+
+            await using var connection = new SqlConnection(connectionStrings.GetConnectionString(connectionStringKey));
+            await connection.OpenAsync();
+
+            var configurationRepository = context.ApplicationContext.Container.Resolve<IConfigurationRepository>();
             foreach (var definition in definitions)
             {
                 _logger.LogInformation("Begin provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
@@ -101,72 +116,78 @@ internal class DataLakeDataMigrator : DataMigrator
                     .Where(stream => stream.OrganizationId == organizationId &&
                             stream.ConnectorProviderDefinitionId == definition.Id)
                     .ToListAsync();
-                //var streamRepository = _applicationContext.Container.Resolve<IStreamRepository>();
-                //var streamsCount = await streamRepository.GetOrganizationStreamsCount(context, filterConnectorProviderDefinitionId: definition.Id);
-                //var streamsPerPage = StreamsPerPage;
-                //var totalPages = (streamsCount + streamsPerPage - 1) / streamsPerPage;
 
-                //for (var i = 0; i < totalPages; ++i)
+                var configuration = configurationRepository.GetConfigurationById(context, definition.Id);
+                if (!IsStreamCacheEnabled(configuration))
                 {
-                    //var streams = await streamRepository.GetOrganizationStreams(context, i, streamsPerPage, filterConnectorProviderDefinitionId: definition.Id);
-                    foreach (var stream in streams)
-                    {
-                        if (stream.Status == StreamStatus.Stopped || stream.Status == StreamStatus.New)
-                        {
-                            _logger.LogInformation("Skipping stream migration for stream '{StreamId}' with status '{StreamStatus}'.",
-                                stream.Id,
-                                stream.Status);
-                            continue;
-                        }
-                        _logger.LogInformation("Updating connector properties for migration for stream '{StreamId}' with status '{StreamStatus}'.",
-                            stream.Id,
-                            stream.Status);
-
-                        var connectorProperties = stream.ConnectorProperties ?? new Dictionary<string, object>();
-                        if (connectorProperties.TryAdd(DataLakeConstants.IsSoftDelete, false))
-                        {
-                            stream.ConnectorProperties = connectorProperties;
-                            await dbContext.SaveChangesAsync();
-                        }
-
-                        var remoteEventService = context.ApplicationContext.Container.Resolve<IRemoteEventService>();
-                        remoteEventService.PublishUpdateStreamEvent(context, stream.Id);
-                        //var mappings = await streamRepository.GetStreamMappings(context, stream.Id);
-
-                        //var connectorProperties = stream.ConnectorProperties == null ? new Dictionary<string, object>() : new Dictionary<string, object>(stream.ConnectorProperties);
-                        //connectorProperties.TryAdd(
-                        //    DataLakeConstants.IsSoftDelete,
-                        //    false);
-                        //var setupConnectorModel = new SetupConnectorModel
-                        //{
-                        //    ConnectorProviderDefinitionId = stream.ConnectorProviderDefinitionId.Value,
-                        //    ContainerName = stream.ContainerName,
-                        //    ExportIncomingEdgeProperties = stream.ExportIncomingEdgeProperties,
-                        //    ExportOutgoingEdgeProperties = stream.ExportOutgoingEdgeProperties,
-                        //    ExportIncomingEdges = stream.ExportIncomingEdges,
-                        //    ExportOutgoingEdges = stream.ExportOutgoingEdges,
-                        //    Mode = stream.Mode.Value,
-                        //    DataTypes = mappings.Select(mapping => new DataTypeEntry
-                        //    {
-                        //        Key = mapping.SourceDataType,
-                        //        Type = mapping.SourceObjectType,
-                        //    }).ToList(),
-                        //    OldContainerName = stream.ContainerName,
-                        //    ConnectorProperties = connectorProperties
-                        //};
-                        //await streamRepository.SetupConnector(context, stream.Id, setupConnectorModel);
-
-                        _logger.LogInformation("Updated connector properties for migration for stream '{StreamId}' with status '{StreamStatus}'.",
-                            stream.Id,
-                            stream.Status);
-                    }
+                    _logger.LogInformation("Stream cache is not enabled for ProviderDefinition '{ProviderDefinitionId}'. Skipping stream migration for soft delete.",
+                        definition.Id);
                 }
 
+                foreach (var stream in streams)
+                {
+                    if (stream.Mode != StreamMode.Sync)
+                    {
+                        _logger.LogInformation("Skipping stream migration for stream '{StreamId}' with mode '{StreamMode}'.",
+                            stream.Id,
+                            stream.Mode);
+                        continue;
+                    }
+
+                    if (stream.Status == StreamStatus.Stopped || stream.Status == StreamStatus.New)
+                    {
+                        _logger.LogInformation("Skipping stream migration for stream '{StreamId}' with status '{StreamStatus}'.",
+                            stream.Id,
+                            stream.Status);
+                        continue;
+                    }
+
+                    var tableName = CacheTableHelper.GetCacheTableName(stream.Id);
+                    _logger.LogInformation("Begin migrating export table '{tableName}' for stream '{StreamId}' for soft delete migration.",
+                        tableName,
+                        stream.Id);
+                    try
+                    {
+                        var alterTableSql = $"ALTER TABLE [{tableName}] ADD [{DataLakeConstants.ChangeTypeKey}] [nvarchar](MAX) NULL";
+                        var command = new SqlCommand(alterTableSql, connection)
+                        {
+                            CommandType = CommandType.Text
+                        };
+
+                        _ = await command.ExecuteNonQueryAsync();
+                    }
+                    catch (SqlException writeDataException) when (writeDataException.IsCannotFindTableException())
+                    {
+                        _logger.LogWarning(writeDataException, "Cache table '{TableName}' is not found for stream '{StreamId}'. It is possible that the stream cache table has not been created yet. Skipping this stream for soft delete migration.",
+                            tableName,
+                            stream.Id);
+                    }
+                    catch (SqlException writeDataException) when (writeDataException.IsColumnAlreadyExistsException())
+                    {
+                        _logger.LogWarning(writeDataException, "Column '{ColumnName}' already exists in cache table '{TableName}' for stream '{StreamId}'. It is possible that this stream has already been migrated for soft delete. Skipping this stream for soft delete migration.",
+                            DataLakeConstants.ChangeTypeKey,
+                            tableName,
+                            stream.Id);
+                    }
+                    _logger.LogInformation("End migrating export table '{tableName}' for stream '{StreamId}' for soft delete migration.",
+                        tableName,
+                        stream.Id);
+                }
                 _logger.LogInformation("End provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
                     componentMigrationName,
                     organizationId,
                     definition.Id);
             }
         }
+    }
+    protected bool IsStreamCacheEnabled(IDictionary<string, object> configuration)
+    {
+        if (configuration.TryGetValue(DataLakeConstants.IsStreamCacheEnabled, out var value))
+        {
+            var casted = value as bool?;
+            return casted is true;
+        }
+
+        return false;
     }
 }

--- a/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataLakeDataMigrator.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using CluedIn.Core;
 using CluedIn.Core.Data.Relational;
 using CluedIn.Core.DataStore.Entities;
+using CluedIn.Core.Events;
 using CluedIn.Core.Streams;
+using CluedIn.Core.Streams.Models;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -14,6 +17,7 @@ namespace CluedIn.Connector.DataLake.Common;
 
 internal class DataLakeDataMigrator : DataMigrator
 {
+    private readonly DbContextOptions<CluedInEntities> _cluedInEntitiesDbContextOptions;
     protected readonly IDataLakeConstants _dataLakeConstants;
     protected readonly IDataLakeJobDataFactory _dataLakeJobDataFactory;
     private const int StreamsPerPage = 100;
@@ -26,6 +30,7 @@ internal class DataLakeDataMigrator : DataMigrator
         IDataLakeConstants constants,
         IDataLakeJobDataFactory dataLakeJobDataFactory) : base (logger, applicationContext, cluedInEntitiesDbContextOptions, componentName)
     {
+        _cluedInEntitiesDbContextOptions = cluedInEntitiesDbContextOptions;
         _dataLakeConstants = constants ?? throw new ArgumentNullException(nameof(constants));
         _dataLakeJobDataFactory = dataLakeJobDataFactory ?? throw new ArgumentNullException(nameof(dataLakeJobDataFactory));
     }
@@ -77,34 +82,83 @@ internal class DataLakeDataMigrator : DataMigrator
         await MigrateForOrganizations("SoftDeleteDefault", MigrateSoftDeleteForProviderDefinition);
         async Task MigrateSoftDeleteForProviderDefinition(ExecutionContext context, string componentMigrationName)
         {
+            await using var dbContext = new CluedInEntities(_cluedInEntitiesDbContextOptions);
             var organizationId = context.Organization.Id;
             var store = context.Organization.DataStores.GetDataStore<ProviderDefinition>();
             var definitions = await store.SelectAsync(
                 context,
                 definition => definition.OrganizationId == context.Organization.Id
                                 && definition.ProviderId == _dataLakeConstants.ProviderId);
+
             foreach (var definition in definitions)
             {
                 _logger.LogInformation("Begin provider definition migration: '{MigrationName}' for organization '{OrganizationId}' and ProviderDefinition '{ProviderDefinitionId}'.",
                     componentMigrationName,
                     organizationId,
                     definition.Id);
-                var streamRepository = _applicationContext.Container.Resolve<IStreamRepository>();
-                var streamsCount = await streamRepository.GetOrganizationStreamsCount(context, filterConnectorProviderDefinitionId: definition.Id);
-                var streamsPerPage = StreamsPerPage;
-                var totalPages = (streamsCount + streamsPerPage - 1) / streamsPerPage;
 
-                for (var i = 0; i < totalPages; ++i)
+                var streams = await dbContext.Streams
+                    .Where(stream => stream.OrganizationId == organizationId &&
+                            stream.ConnectorProviderDefinitionId == definition.Id)
+                    .ToListAsync();
+                //var streamRepository = _applicationContext.Container.Resolve<IStreamRepository>();
+                //var streamsCount = await streamRepository.GetOrganizationStreamsCount(context, filterConnectorProviderDefinitionId: definition.Id);
+                //var streamsPerPage = StreamsPerPage;
+                //var totalPages = (streamsCount + streamsPerPage - 1) / streamsPerPage;
+
+                //for (var i = 0; i < totalPages; ++i)
                 {
-                    var streams = await streamRepository.GetOrganizationStreams(context, i, streamsPerPage, filterConnectorProviderDefinitionId: definition.Id);
+                    //var streams = await streamRepository.GetOrganizationStreams(context, i, streamsPerPage, filterConnectorProviderDefinitionId: definition.Id);
                     foreach (var stream in streams)
                     {
-                        var connectorProperties = stream.ConnectorProperties == null ? new Dictionary<string, object>() : new Dictionary<string, object>(stream.ConnectorProperties);
-                        connectorProperties.TryAdd(
-                            DataLakeConstants.IsSoftDelete,
-                            false);
+                        if (stream.Status == StreamStatus.Stopped || stream.Status == StreamStatus.New)
+                        {
+                            _logger.LogInformation("Skipping stream migration for stream '{StreamId}' with status '{StreamStatus}'.",
+                                stream.Id,
+                                stream.Status);
+                            continue;
+                        }
+                        _logger.LogInformation("Updating connector properties for migration for stream '{StreamId}' with status '{StreamStatus}'.",
+                            stream.Id,
+                            stream.Status);
 
-                        await streamRepository.UpdateStream(context, stream.Id, stream, context.Organization.Id, stream.ModifiedBy);
+                        var connectorProperties = stream.ConnectorProperties ?? new Dictionary<string, object>();
+                        if (connectorProperties.TryAdd(DataLakeConstants.IsSoftDelete, false))
+                        {
+                            stream.ConnectorProperties = connectorProperties;
+                            await dbContext.SaveChangesAsync();
+                        }
+
+                        var remoteEventService = context.ApplicationContext.Container.Resolve<IRemoteEventService>();
+                        remoteEventService.PublishUpdateStreamEvent(context, stream.Id);
+                        //var mappings = await streamRepository.GetStreamMappings(context, stream.Id);
+
+                        //var connectorProperties = stream.ConnectorProperties == null ? new Dictionary<string, object>() : new Dictionary<string, object>(stream.ConnectorProperties);
+                        //connectorProperties.TryAdd(
+                        //    DataLakeConstants.IsSoftDelete,
+                        //    false);
+                        //var setupConnectorModel = new SetupConnectorModel
+                        //{
+                        //    ConnectorProviderDefinitionId = stream.ConnectorProviderDefinitionId.Value,
+                        //    ContainerName = stream.ContainerName,
+                        //    ExportIncomingEdgeProperties = stream.ExportIncomingEdgeProperties,
+                        //    ExportOutgoingEdgeProperties = stream.ExportOutgoingEdgeProperties,
+                        //    ExportIncomingEdges = stream.ExportIncomingEdges,
+                        //    ExportOutgoingEdges = stream.ExportOutgoingEdges,
+                        //    Mode = stream.Mode.Value,
+                        //    DataTypes = mappings.Select(mapping => new DataTypeEntry
+                        //    {
+                        //        Key = mapping.SourceDataType,
+                        //        Type = mapping.SourceObjectType,
+                        //    }).ToList(),
+                        //    OldContainerName = stream.ContainerName,
+                        //    ConnectorProperties = connectorProperties
+                        //};
+                        //await streamRepository.SetupConnector(context, stream.Id, setupConnectorModel);
+
+                        _logger.LogInformation("Updated connector properties for migration for stream '{StreamId}' with status '{StreamStatus}'.",
+                            stream.Id,
+                            stream.Status);
                     }
                 }
 

--- a/src/Connector.DataLake.Common/DataLakeJobData.cs
+++ b/src/Connector.DataLake.Common/DataLakeJobData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace CluedIn.Connector.DataLake.Common;
@@ -21,6 +21,8 @@ internal abstract class DataLakeJobData : CrawlJobDataWrapper, IDataLakeJobData
     public virtual bool ShouldEscapeVocabularyKeys => GetConfigurationValue(DataLakeConstants.ShouldEscapeVocabularyKeys) as bool? ?? false;
     public string CustomCron => GetConfigurationValue(DataLakeConstants.CustomCron) as string;
     public virtual bool IsDeltaMode => GetConfigurationValue(DataLakeConstants.IsDeltaMode) as bool? ?? false;
+
+    public virtual bool IsSoftDelete => GetConfigurationValue(DataLakeConstants.IsSoftDelete) as bool? ?? true;
     public virtual bool IsOverwriteEnabled => GetConfigurationValue(DataLakeConstants.IsOverwriteEnabled) as bool? ?? true;
     public virtual bool IsArrayColumnsEnabled => GetConfigurationValue(DataLakeConstants.IsArrayColumnsEnabled) as bool? ?? false;
 

--- a/src/Connector.DataLake.Common/DataLakeJobDataFactoryBase.cs
+++ b/src/Connector.DataLake.Common/DataLakeJobDataFactoryBase.cs
@@ -49,7 +49,7 @@ public abstract class DataLakeJobDataFactoryBase
         var authenticationDetails = await GetAuthenticationDetails(executionContext, providerDefinitionId);
         var authenticationDetailsDict = authenticationDetails.Authentication.ToDictionary(detail => detail.Key, detail => detail.Value);
 
-        if (streamModel.ConnectorProperties == null)
+        if (streamModel.ConnectorProperties != null)
         {
             foreach (var property in streamModel.ConnectorProperties!)
             {

--- a/src/Connector.DataLake.Common/DataLakeJobDataFactoryBase.cs
+++ b/src/Connector.DataLake.Common/DataLakeJobDataFactoryBase.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 using CluedIn.Core;
 using CluedIn.Core.Connectors;
+using CluedIn.Core.Streams.Models;
 
 namespace CluedIn.Connector.DataLake.Common;
 
@@ -32,10 +33,31 @@ public abstract class DataLakeJobDataFactoryBase
         }
     }
 
-    public virtual async Task<IDataLakeJobData> GetConfiguration(ExecutionContext executionContext, Guid providerDefinitionId, string containerName)
+    public virtual async Task<IDataLakeJobData> GetConfiguration(ExecutionContext executionContext, Guid providerDefinitionId)
     {
         var authenticationDetails = await GetAuthenticationDetails(executionContext, providerDefinitionId);
-        return await GetConfiguration(executionContext, authenticationDetails.Authentication.ToDictionary(detail => detail.Key, detail => detail.Value), containerName);
+        return await GetConfiguration(
+            executionContext,
+            authenticationDetails.Authentication.ToDictionary(detail => detail.Key, detail => detail.Value),
+            string.Empty);
+    }
+
+    public virtual async Task<IDataLakeJobData> GetConfiguration(ExecutionContext executionContext, IReadOnlyStreamModel streamModel)
+    {
+        var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
+        var containerName = streamModel.ContainerName;
+        var authenticationDetails = await GetAuthenticationDetails(executionContext, providerDefinitionId);
+        var authenticationDetailsDict = authenticationDetails.Authentication.ToDictionary(detail => detail.Key, detail => detail.Value);
+
+        if (streamModel.ConnectorProperties == null)
+        {
+            foreach (var property in streamModel.ConnectorProperties!)
+            {
+                authenticationDetailsDict[property.Key] = property.Value;
+            }
+        }
+
+        return await GetConfiguration(executionContext, authenticationDetailsDict, containerName);
     }
 
     public virtual async Task<IDataLakeJobData> GetConfiguration(ExecutionContext executionContext, IDictionary<string, object> authenticationDetails, string containerName = null)

--- a/src/Connector.DataLake.Common/DataLakeJobDataFactoryExtensions.cs
+++ b/src/Connector.DataLake.Common/DataLakeJobDataFactoryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using CluedIn.Core;
@@ -13,8 +13,7 @@ internal static class DataLakeJobDataFactoryExtensions
     {
         var configurations = await jobDataFactory.GetConfiguration(
             context,
-            stream.ConnectorProviderDefinitionId.Value,
-            stream.ContainerName);
+            stream);
 
         if (configurations.IsStreamCacheEnabled
             && stream.Status == StreamStatus.Started

--- a/src/Connector.DataLake.Common/DataMigrator.cs
+++ b/src/Connector.DataLake.Common/DataMigrator.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using CluedIn.Connector.DataLake.Common.Connector;

--- a/src/Connector.DataLake.Common/EventHandlers/UpdateExportTargetEventHandler.cs
+++ b/src/Connector.DataLake.Common/EventHandlers/UpdateExportTargetEventHandler.cs
@@ -49,7 +49,7 @@ internal class UpdateExportTargetEventHandler : UpdateStreamScheduleBase, IDispo
 
         var streamRepository = ApplicationContext.Container.Resolve<IStreamRepository>();
         var executionContext = ApplicationContext.CreateExecutionContext(organizationId);
-        var streamsCount = await streamRepository.GetOrganizationStreamsCount(executionContext);
+        var streamsCount = await streamRepository.GetOrganizationStreamsCount(executionContext, filterConnectorProviderDefinitionId: providerDefinitionId);
         var streamsPerPage = StreamsPerPage;
         var totalPages = (streamsCount + streamsPerPage - 1) / streamsPerPage;
 

--- a/src/Connector.DataLake.Common/IDataLakeJobData.cs
+++ b/src/Connector.DataLake.Common/IDataLakeJobData.cs
@@ -1,4 +1,4 @@
-﻿namespace CluedIn.Connector.DataLake.Common;
+namespace CluedIn.Connector.DataLake.Common;
 
 public interface IDataLakeJobData
 {
@@ -19,4 +19,5 @@ public interface IDataLakeJobData
     string FileSystemName { get; }
 
     string RootDirectoryPath { get; }
+    bool IsSoftDelete { get; }
 }

--- a/src/Connector.DataLake.Common/IDataLakeJobDataFactory.cs
+++ b/src/Connector.DataLake.Common/IDataLakeJobDataFactory.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using CluedIn.Core;
+using CluedIn.Core.Streams.Models;
 
 namespace CluedIn.Connector.DataLake.Common;
 
@@ -10,8 +11,11 @@ public interface IDataLakeJobDataFactory
 {
     Task<IDataLakeJobData> GetConfiguration(
         ExecutionContext executionContext,
-        Guid providerDefinitionId,
-        string containerName);
+        Guid providerDefinitionId);
+
+    Task<IDataLakeJobData> GetConfiguration(
+        ExecutionContext executionContext,
+        IReadOnlyStreamModel streamModel);
 
     Task<IDataLakeJobData> GetConfiguration(
         ExecutionContext executionContext,

--- a/src/Connector.FabricOpenMirroring/Connector/OpenMirroringConnector.cs
+++ b/src/Connector.FabricOpenMirroring/Connector/OpenMirroringConnector.cs
@@ -108,7 +108,7 @@ public class OpenMirroringConnector : DataLakeConnector
         var providerDefinitionId = streamModel.ConnectorProviderDefinitionId!.Value;
         var containerName = streamModel.ContainerName;
 
-        var jobData = await DataLakeJobDataFactory.GetConfiguration(executionContext, providerDefinitionId, containerName);
+        var jobData = await DataLakeJobDataFactory.GetConfiguration(executionContext, streamModel);
         var subDirectory = await OutputDirectoryHelper.GetSubDirectory(executionContext, jobData, streamModel.Id, containerName, _dateTimeOffsetProvider.GetCurrentUtcTime(), jobData.OutputFormat);
         await Client.DeleteDirectory(jobData, subDirectory);
         await base.ArchiveContainer(executionContext, streamModel);

--- a/src/Connector.FabricOpenMirroring/EventHandlers/ExportTargetEventHandler.cs
+++ b/src/Connector.FabricOpenMirroring/EventHandlers/ExportTargetEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 using CluedIn.Connector.DataLake.Common;
@@ -100,7 +100,7 @@ internal class ExportTargetEventHandler : IDisposable
             return;
         }
 
-        var jobData = await _jobDataFactory.GetConfiguration(executionContext, providerDefinitionId, string.Empty) as OpenMirroringConnectorJobData;
+        var jobData = await _jobDataFactory.GetConfiguration(executionContext, providerDefinitionId) as OpenMirroringConnectorJobData;
         if (jobData == null)
         {
             throw new ApplicationException($"Failed to get job data for ProviderDefinitionId {providerDefinitionId}.");

--- a/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
+++ b/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
@@ -552,6 +552,36 @@ public class AzureDataLakeConnectorTests : DataLakeConnectorTestsBase<AzureDataL
         Assert.NotEmpty(containers);
     }
 
+    [Fact]
+    public async Task VerifyStoreData_Sync_WithStreamCacheCanIgnoreWhenChangedAfterDeletion()
+    {
+        await VerifyStoreData_Sync_WithStreamCache("csv",
+            async (fileClient, _, _) => await AssertCsvResult(fileClient, "_", (rows) =>
+            {
+                var removed = rows.ToList();
+                removed.Clear();
+                return removed;
+            }),
+            getConnectorEntityData: () =>
+            {
+                var initialUserData = UserData.Default;
+                var removedUserData = initialUserData with { Age = initialUserData.Age + 1 };
+                var readdAfterDeletionUserData = initialUserData with { Age = initialUserData.Age + 2 };
+
+                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
+                var removedEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Removed, persistVersion: 2, userData: removedUserData);
+                var readdAfterDeletionEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 3, userData: readdAfterDeletionUserData);
+
+                // Intermediate version is outdated when final version is stored, so it should be ignored and not cause the export to fail
+                return new[] { initialEntityData, removedEntityData, readdAfterDeletionEntityData };
+            },
+            configureAuthentication: (values) =>
+            {
+                values.Add(nameof(DataLakeConstants.ShouldEscapeVocabularyKeys), true);
+                values.Add(nameof(DataLakeConstants.ShouldWriteGuidAsString), true);
+            });
+    }
+
     private protected override async Task VerifyStoreData_Sync_WithStreamCache(
         string format,
         Func<DataLakeFileClient, DataLakeFileSystemClient, SetupContainerResult, Task> assertMethod,
@@ -559,6 +589,7 @@ public class AzureDataLakeConnectorTests : DataLakeConnectorTestsBase<AzureDataL
         Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
         Action<Dictionary<string, object>> configureAuthentication = null,
         Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<SetupContainerResult, ConnectorEntityData, Task> storeData = null,
         Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null)
     {
         var configuration = CreateConfigurationWithStreamCache(format);
@@ -573,7 +604,14 @@ public class AzureDataLakeConnectorTests : DataLakeConnectorTestsBase<AzureDataL
             : getConnectorEntityData();
         foreach (var data in connectorEntityData)
         {
+            if (storeData != null)
+            {
+                await storeData(setupResult, data);
+                continue;
+            }
+
             await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+            await ModifyHistoryTimeToBeCurrentTime(setupResult, data);
         }
         var exportJob = CreateExportJob(setupResult);
 

--- a/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
+++ b/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
@@ -13,6 +13,7 @@ using CluedIn.Connector.DataLake.Common;
 using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Connector.DataLake.Common.Tests.Integration;
 using CluedIn.Core;
+using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
 
@@ -551,12 +552,14 @@ public class AzureDataLakeConnectorTests : DataLakeConnectorTestsBase<AzureDataL
         Assert.NotEmpty(containers);
     }
 
-    private async Task VerifyStoreData_Sync_WithStreamCache(
+    private protected override async Task VerifyStoreData_Sync_WithStreamCache(
         string format,
         Func<DataLakeFileClient, DataLakeFileSystemClient, SetupContainerResult, Task> assertMethod,
         Func<ExecuteExportArg, Task<PathItem>> executeExport = null,
         Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
-        Action<Dictionary<string, object>> configureAuthentication = null)
+        Action<Dictionary<string, object>> configureAuthentication = null,
+        Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null)
     {
         var configuration = CreateConfigurationWithStreamCache(format);
         configureAuthentication?.Invoke(configuration);
@@ -565,8 +568,13 @@ public class AzureDataLakeConnectorTests : DataLakeConnectorTestsBase<AzureDataL
         var setupResult = await SetupContainer(jobData, StreamMode.Sync, configureTimeProvider);
         var connector = setupResult.ConnectorMock.Object;
 
-        var data = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added);
-        await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+        var connectorEntityData = getConnectorEntityData == null
+            ? [CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added)]
+            : getConnectorEntityData();
+        foreach (var data in connectorEntityData)
+        {
+            await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+        }
         var exportJob = CreateExportJob(setupResult);
 
         await AssertExportJobOutputFileContents(

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
@@ -183,7 +183,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
         var constantsMock = CreateConstantsMock();
         var jobDataFactoryMock = CreateJobDataFactoryMock(container);
         var connectorMock = GetConnectorMock(mockDateTimeOffsetProvider, constantsMock, jobDataFactoryMock);
-        jobDataFactoryMock.Setup(x => x.GetConfiguration(It.IsAny<ExecutionContext>(), providerDefinitionId, It.IsAny<string>()))
+        jobDataFactoryMock.Setup(x => x.GetConfiguration(It.IsAny<ExecutionContext>(), It.IsAny<IReadOnlyStreamModel>()))
             .ReturnsAsync(jobData);
         connectorMock.CallBase = true;
 

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Azure;
+using Azure.Storage;
 using Azure.Storage.Files.DataLake;
 using Azure.Storage.Files.DataLake.Models;
 
@@ -41,6 +42,7 @@ using Parquet;
 
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 
@@ -51,6 +53,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
     where TJobDataFactory : class, IDataLakeJobDataFactory
     where TConstants : class, IDataLakeConstants
 {
+    private const int NotTemporalTableErrorCode = 13591;
     private readonly ITestOutputHelper _testOutputHelper;
     private static readonly DateTimeOffset _defaultCurrentTime = new(2024, 8, 21, 3, 16, 0, TimeSpan.FromHours(5));
 
@@ -58,6 +61,135 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
     public DataLakeConnectorTestsBase(ITestOutputHelper testOutputHelper)
     {
         _testOutputHelper = testOutputHelper ?? throw new ArgumentNullException(nameof(testOutputHelper));
+    }
+
+    private protected abstract Task VerifyStoreData_Sync_WithStreamCache(
+        string format,
+        Func<DataLakeFileClient, DataLakeFileSystemClient, SetupContainerResult, Task> assertMethod,
+        Func<ExecuteExportArg, Task<PathItem>> executeExport = null,
+        Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
+        Action<Dictionary<string, object>> configureAuthentication = null,
+        Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null);
+
+    [Fact]
+    public async Task VerifyStoreData_Sync_WithStreamCacheCanHandleMultipleUpdates()
+    {
+        var initialUserData = UserData.Default;
+        var firstChangeUserData = initialUserData with { Age = initialUserData.Age + 1 };
+        var secondChangeUserData = initialUserData with { Age = initialUserData.Age + 2 };
+        await VerifyStoreData_Sync_WithStreamCache("csv",
+            async (fileClient, _, _) => await AssertCsvResult(fileClient, "_", (rows) =>
+            {
+                var updated = rows.ToList();
+                updated[0].Columns[DataLakeConstants.PersistVersionKey] = 3.ToString();
+                updated[0].Columns["user_age"] = secondChangeUserData.Age.ToString();
+                return updated;
+            }),
+            getConnectorEntityData: () =>
+            {
+                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
+                var firstChangeEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 2, userData: firstChangeUserData);
+                var secondChangeEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 3, userData: secondChangeUserData);
+
+                return new[] { initialEntityData, firstChangeEntityData, secondChangeEntityData };
+            },
+            configureAuthentication: (values) =>
+            {
+                values.Add(nameof(DataLakeConstants.ShouldEscapeVocabularyKeys), true);
+                values.Add(nameof(DataLakeConstants.ShouldWriteGuidAsString), true);
+            });
+    }
+
+    [Fact]
+    public async Task VerifyStoreData_Sync_WithStreamCacheCanIgnoreOutdatedValues()
+    {
+        var initialUserData = UserData.Default;
+        var firstChangeUserData = initialUserData with { Age = initialUserData.Age + 1 };
+        var secondChangeUserData = initialUserData with { Age = initialUserData.Age + 2 };
+        await VerifyStoreData_Sync_WithStreamCache("csv",
+            async (fileClient, _, _) => await AssertCsvResult(fileClient, "_", (rows) =>
+            {
+                var updated = rows.ToList();
+                updated[0].Columns[DataLakeConstants.PersistVersionKey] = 3.ToString();
+                updated[0].Columns["user_age"] = secondChangeUserData.Age.ToString();
+                return updated;
+            }),
+            getConnectorEntityData: () =>
+            {
+                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
+                var firstChangeEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 2, userData: firstChangeUserData);
+                var secondChangeEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 3, userData: secondChangeUserData);
+
+                // Second change is the most recent version, so first change should be ignored and not cause the export to fail
+                return new[] { initialEntityData, secondChangeEntityData, firstChangeEntityData };
+            },
+            configureAuthentication: (values) =>
+            {
+                values.Add(nameof(DataLakeConstants.ShouldEscapeVocabularyKeys), true);
+                values.Add(nameof(DataLakeConstants.ShouldWriteGuidAsString), true);
+            });
+    }
+
+    [Fact]
+    public async Task VerifyStoreData_Sync_WithStreamCacheCanIgnoreWhenChangedAfterDeletion()
+    {
+        await VerifyStoreData_Sync_WithStreamCache("csv",
+            async (fileClient, _, _) => await AssertCsvResult(fileClient, "_", (rows) =>
+            {
+                var removed = rows.ToList();
+                removed.Clear();
+                return removed;
+            }),
+            getConnectorEntityData: () =>
+            {
+                var initialUserData = UserData.Default;
+                var removedUserData = initialUserData with { Age = initialUserData.Age + 1 };
+                var readdAfterDeletionUserData = initialUserData with { Age = initialUserData.Age + 2 };
+
+                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
+                var removedEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Removed, persistVersion: 2, userData: removedUserData);
+                var readdAfterDeletionEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 3, userData: readdAfterDeletionUserData);
+
+                // Intermediate version is outdated when final version is stored, so it should be ignored and not cause the export to fail
+                return new[] { initialEntityData, removedEntityData, readdAfterDeletionEntityData };
+            },
+            configureAuthentication: (values) =>
+            {
+                values.Add(nameof(DataLakeConstants.ShouldEscapeVocabularyKeys), true);
+                values.Add(nameof(DataLakeConstants.ShouldWriteGuidAsString), true);
+            });
+    }
+
+    [Fact]
+    public async Task VerifyStoreData_Sync_WithStreamCacheCanReAddAfterDeletion()
+    {
+        var initialUserData = UserData.Default;
+        var removedUserData = initialUserData with { Age = initialUserData.Age + 1 };
+        var readdUserData = initialUserData with { Age = initialUserData.Age + 2 };
+        await VerifyStoreData_Sync_WithStreamCache("csv",
+            async (fileClient, _, _) => await AssertCsvResult(fileClient, "_", (rows) =>
+            {
+                var updated = rows.ToList();
+                updated[0].Columns[DataLakeConstants.PersistVersionKey] = 3.ToString();
+                updated[0].Columns["user_age"] = readdUserData.Age.ToString();
+                return updated;
+            }),
+            getConnectorEntityData: () =>
+            {
+
+                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
+                var removedEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Removed, persistVersion: 2, userData: removedUserData);
+                var readdEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 3, userData: readdUserData);
+
+                // Intermediate version is outdated when final version is stored, so it should be ignored and not cause the export to fail
+                return new[] { initialEntityData, removedEntityData, readdEntityData };
+            },
+            configureAuthentication: (values) =>
+            {
+                values.Add(nameof(DataLakeConstants.ShouldEscapeVocabularyKeys), true);
+                values.Add(nameof(DataLakeConstants.ShouldWriteGuidAsString), true);
+            });
     }
 
     private protected Task<SetupContainerResult> SetupContainer<TJobData>(
@@ -390,8 +522,6 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
 
     protected static async Task DeleteTable(Guid streamId, string streamCacheConnectionString)
     {
-        await using var connection = new SqlConnection(streamCacheConnectionString);
-        await connection.OpenAsync();
         var tableName = CacheTableHelper.GetCacheTableName(streamId);
         var deleteTableSql = $"""
             IF EXISTS (SELECT * FROM SYSOBJECTS WHERE NAME='{tableName}' AND XTYPE='U')
@@ -400,14 +530,35 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
             DROP TABLE IF EXISTS [{tableName}];
             DROP TABLE IF EXISTS [{tableName}_History];
             """;
-        var command = new SqlCommand(deleteTableSql, connection)
+        try
         {
-            CommandType = CommandType.Text
-        };
-        _ = await command.ExecuteNonQueryAsync();
+            await DeleteTableInternal(deleteTableSql, streamCacheConnectionString);
+        }
+        catch (SqlException ex) when (ex.Number == NotTemporalTableErrorCode)
+        {
+            var historyTable = $"{tableName}_History";
+            var deleteTableSeparatelySql = $"""
+                IF EXISTS (SELECT * FROM SYSOBJECTS WHERE NAME='{tableName}' AND XTYPE='U')
+                DROP TABLE IF EXISTS [{tableName}];
+                DROP TABLE IF EXISTS [{tableName}_History];
+                """;
+            await DeleteTableInternal(deleteTableSeparatelySql, streamCacheConnectionString);
+        }
+
+        static async Task DeleteTableInternal(string deleteTableSql, string streamCacheConnectionString)
+        {
+            await using var connection = new SqlConnection(streamCacheConnectionString);
+            await connection.OpenAsync();
+
+            var command = new SqlCommand(deleteTableSql, connection)
+            {
+                CommandType = CommandType.Text
+            };
+            _ = await command.ExecuteNonQueryAsync();
+        }
     }
 
-    private protected static async Task ModifyHistoryTimeToBeCurrentTime(SetupContainerResult setupContainerResult)
+    private protected async Task ModifyHistoryTimeToBeCurrentTime(SetupContainerResult setupContainerResult)
     {
         var jobData = setupContainerResult.DataLakeJobData;
         var connectionString = jobData.StreamCacheConnectionString;
@@ -425,14 +576,21 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
             await EnableHistory(connection, tableName);
             await AssertRowCount(connection, tableName);
         }
-        catch
+        catch (Exception ex)
         {
+            _testOutputHelper.WriteLine(ex.Message + Environment.NewLine + ex.StackTrace);
             await DeleteTable(streamModel.Id, jobData.StreamCacheConnectionString);
+            throw;
         }
 
         static async Task EnableHistory(SqlConnection connection, string tableName)
         {
-            var enableHistorySql = $"ALTER TABLE [dbo].[{tableName}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{tableName}_History], DATA_CONSISTENCY_CHECK = ON));";
+            var enableHistorySql = $"""
+                    ALTER TABLE [dbo].[{tableName}] ADD PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]);
+                    ALTER TABLE [dbo].[{tableName}] ALTER COLUMN [ValidFrom] ADD HIDDEN;
+                    ALTER TABLE [dbo].[{tableName}] ALTER COLUMN [ValidTo] ADD HIDDEN;
+                    ALTER TABLE [dbo].[{tableName}] SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = [dbo].[{tableName}_History], DATA_CONSISTENCY_CHECK = ON));
+                    """;
 
             var enableHistoryCommand = new SqlCommand(enableHistorySql, connection)
             {
@@ -457,18 +615,47 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
 
         static async Task AlterHistory(Mock<IDateTimeOffsetProvider> mockDateTimeOffsetProvider, SqlConnection connection, string tableName)
         {
-            var alterHistorySql = $"""
-                    UPDATE [dbo].[{tableName}] SET [ValidFrom] = @ValidFrom;
-                    ALTER TABLE [dbo].[{tableName}] ADD PERIOD FOR SYSTEM_TIME ([ValidFrom], [ValidTo]);
-                    ALTER TABLE [dbo].[{tableName}] ALTER COLUMN [ValidFrom] ADD HIDDEN;
-                    ALTER TABLE [dbo].[{tableName}] ALTER COLUMN [ValidTo] ADD HIDDEN;
-                    """;
-            var alterHistoryCommand = new SqlCommand(alterHistorySql, connection)
+            var targetTime = mockDateTimeOffsetProvider.Object.GetCurrentUtcTime();
+
+            await AdjustTimeAsync(connection, "ValidFrom", tableName, targetTime, shouldUpdateValidTo: false);
+            await AdjustTimeAsync(connection, "ValidTo", $"{tableName}_History", targetTime, shouldUpdateValidTo: true);
+
+            static async Task AdjustTimeAsync(SqlConnection connection, string maxDateColumn, string tableNameToAdjust, DateTimeOffset targetTime, bool shouldUpdateValidTo)
             {
-                CommandType = CommandType.Text,
-            };
-            alterHistoryCommand.Parameters.Add(new SqlParameter("@ValidFrom", mockDateTimeOffsetProvider.Object.GetCurrentUtcTime()));
-            await alterHistoryCommand.ExecuteNonQueryAsync();
+                ICollection<string> dateParts = ["YEAR", "MONTH", "HOUR", "MINUTE", "SECOND", "MICROSECOND", "NANOSECOND"];
+
+                foreach (var datePart in dateParts)
+                {
+                    var getHistorySql = $"""
+                        SELECT DATEDIFF_BIG({datePart}, MAX([{maxDateColumn}]), @CurrentTime)
+                        FROM [dbo].[{tableNameToAdjust}];
+                        """;
+                    using var getHistoryCommand = new SqlCommand(getHistorySql, connection);
+                    getHistoryCommand.Parameters.Add(new SqlParameter("@CurrentTime", targetTime));
+                    var diff = await getHistoryCommand.ExecuteScalarAsync() as long?;
+
+                    if (diff == null)
+                    {
+                        continue;
+                    }
+
+                    var updateValidTo = shouldUpdateValidTo ? $",[ValidTo] = DATEADD({datePart}, @DateDiff, [ValidTo])" : string.Empty;
+                    var alterHistoryTimeSql = $"""
+                    UPDATE
+                        [dbo].[{tableNameToAdjust}]
+                    SET
+                        [ValidFrom] = DATEADD({datePart}, @DateDiff, [ValidFrom])
+                        {updateValidTo};
+                    """;
+                    using var alterHistoryTimeCommand = new SqlCommand(alterHistoryTimeSql, connection)
+                    {
+                        CommandType = CommandType.Text,
+                    };
+                    alterHistoryTimeCommand.Parameters.Add(new SqlParameter("@DateDiff", diff));
+                    await alterHistoryTimeCommand.ExecuteNonQueryAsync();
+                }
+            }
+
         }
 
         static async Task AssertRowCount(SqlConnection connection, string tableName)
@@ -530,7 +717,8 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
 
     private void AssertResult(List<DataRow> actualRows, List<DataRow> expectedRows)
     {
-        TestOutputHelper.WriteLine(JsonConvert.SerializeObject(actualRows, Formatting.Indented));
+        TestOutputHelper.WriteLine("Actual"  + Environment.NewLine + JsonConvert.SerializeObject(actualRows, Formatting.Indented));
+        TestOutputHelper.WriteLine("Expected" + Environment.NewLine + JsonConvert.SerializeObject(actualRows, Formatting.Indented));
         Assert.Equal(actualRows.Count, actualRows.Count);
         for (var i = 0; i < expectedRows.Count; i++)
         {
@@ -850,19 +1038,25 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
     protected ITestOutputHelper TestOutputHelper => _testOutputHelper;
     protected static DateTimeOffset DefaultCurrentTime => _defaultCurrentTime;
 
-    public ConnectorEntityData CreateBaseConnectorEntityData(StreamMode streamMode, VersionChangeType versionChangeType)
+    private protected ConnectorEntityData CreateBaseConnectorEntityData(
+        StreamMode streamMode,
+        VersionChangeType versionChangeType,
+        int persistVersion = 1,
+        UserData? userData = null)
     {
-        var dobInDateTime = new DateTime(2000, 01, 02, 03, 04, 05);
-        var dobInDateTimeOffset = new DateTimeOffset(2000, 01, 02, 03, 04, 05, TimeSpan.FromMinutes(12 * 60 + 34));
+        var userDataToUse = userData ?? UserData.Default;
+        var dobInDateTimeOffset = userDataToUse.DobInDateTimeOffset;
+        var dobInDateTime = dobInDateTimeOffset.DateTime;
+
         var data = new ConnectorEntityData(versionChangeType, streamMode,
             Guid.Parse("f55c66dc-7881-55c9-889f-344992e71cb8"),
-            new ConnectorEntityPersistInfo("etypzcezkiehwq8vw4oqog==", 1), null,
+            new ConnectorEntityPersistInfo("etypzcezkiehwq8vw4oqog==", persistVersion), null,
             EntityCode.FromKey("/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0"),
             "/Person",
             [
-                new ConnectorPropertyData("user.lastName", "Picard",
+                new ConnectorPropertyData("user.lastName", userDataToUse.LastName,
                     new VocabularyKeyConnectorPropertyDataType(new VocabularyKey("user.lastName"))),
-                new ConnectorPropertyData("user.age", "123",
+                new ConnectorPropertyData("user.age", userDataToUse.Age.ToString(),
                     new VocabularyKeyConnectorPropertyDataType(
                         new VocabularyKey("user.age", dataType: VocabularyKeyDataType.Integer)
                         {
@@ -880,7 +1074,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
                         {
                             Storage = VocabularyKeyStorage.Typed,
                         })),
-                new ConnectorPropertyData("Name", "Jean Luc Picard",
+                new ConnectorPropertyData("Name", userDataToUse.Name,
                     new EntityPropertyConnectorPropertyDataType(typeof(string))),
             ],
             [EntityCode.FromKey("/Person#Acceptance:7c5591cf-861a-4642-861d-3b02485854a0")],
@@ -920,6 +1114,19 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
             string DirectoryName,
             DataLakeServiceClient Client,
             DataLakeExportEntitiesJobBase ExportJob);
+
+    private protected record UserData(
+        string Name,
+        string LastName,
+        int Age,
+        DateTimeOffset DobInDateTimeOffset)
+    {
+        public static UserData Default => new UserData(
+            "Jean Luc Picard",
+            "Picard",
+            123,
+            new DateTimeOffset(2000, 01, 02, 03, 04, 05, TimeSpan.FromMinutes(12 * 60 + 34)));
+    };
 
     public class DataRow
     {

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
@@ -44,6 +44,8 @@ using Xunit;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
+using static CluedIn.Core.Constants.Configuration;
+
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 
 namespace CluedIn.Connector.DataLake.Common.Tests.Integration;
@@ -70,6 +72,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
         Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
         Action<Dictionary<string, object>> configureAuthentication = null,
         Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<SetupContainerResult, ConnectorEntityData, Task> storeData = null,
         Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null);
 
     [Fact]
@@ -123,36 +126,6 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
 
                 // Second change is the most recent version, so first change should be ignored and not cause the export to fail
                 return new[] { initialEntityData, secondChangeEntityData, firstChangeEntityData };
-            },
-            configureAuthentication: (values) =>
-            {
-                values.Add(nameof(DataLakeConstants.ShouldEscapeVocabularyKeys), true);
-                values.Add(nameof(DataLakeConstants.ShouldWriteGuidAsString), true);
-            });
-    }
-
-    [Fact]
-    public async Task VerifyStoreData_Sync_WithStreamCacheCanIgnoreWhenChangedAfterDeletion()
-    {
-        await VerifyStoreData_Sync_WithStreamCache("csv",
-            async (fileClient, _, _) => await AssertCsvResult(fileClient, "_", (rows) =>
-            {
-                var removed = rows.ToList();
-                removed.Clear();
-                return removed;
-            }),
-            getConnectorEntityData: () =>
-            {
-                var initialUserData = UserData.Default;
-                var removedUserData = initialUserData with { Age = initialUserData.Age + 1 };
-                var readdAfterDeletionUserData = initialUserData with { Age = initialUserData.Age + 2 };
-
-                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
-                var removedEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Removed, persistVersion: 2, userData: removedUserData);
-                var readdAfterDeletionEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 3, userData: readdAfterDeletionUserData);
-
-                // Intermediate version is outdated when final version is stored, so it should be ignored and not cause the export to fail
-                return new[] { initialEntityData, removedEntityData, readdAfterDeletionEntityData };
             },
             configureAuthentication: (values) =>
             {
@@ -465,7 +438,6 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
         try
         {
             var fsClient = client.GetFileSystemClient(fileSystemName);
-            await ModifyHistoryTimeToBeCurrentTime(setupContainerResult);
 
             var executeExportArg = new ExecuteExportArg(
                 context,
@@ -474,7 +446,8 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
                 FileSystemName: fileSystemName,
                 DirectoryName: directoryName,
                 client,
-                exportJob);
+                exportJob,
+                setupContainerResult);
 
             var path = executeExport == null
                 ? await DefaultExecuteExport(executeExportArg)
@@ -558,7 +531,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
         }
     }
 
-    private protected async Task ModifyHistoryTimeToBeCurrentTime(SetupContainerResult setupContainerResult)
+    private protected async Task ModifyHistoryTimeToBeCurrentTime(SetupContainerResult setupContainerResult, ConnectorEntityData connectorEntityData)
     {
         var jobData = setupContainerResult.DataLakeJobData;
         var connectionString = jobData.StreamCacheConnectionString;
@@ -582,6 +555,19 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
             await DeleteTable(streamModel.Id, jobData.StreamCacheConnectionString);
             throw;
         }
+
+        static async Task AssertRowCount(SqlConnection connection, string tableName)
+        {
+            var getCountSql = $"SELECT COUNT(*) FROM [{tableName}]";
+            var sqlCommand = new SqlCommand(getCountSql, connection)
+            {
+                CommandType = CommandType.Text,
+            };
+            var total = (int)await sqlCommand.ExecuteScalarAsync();
+
+            Assert.Equal(1, total);
+        }
+
 
         static async Task EnableHistory(SqlConnection connection, string tableName)
         {
@@ -613,63 +599,100 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
             await disableHistoryCommand.ExecuteNonQueryAsync();
         }
 
-        static async Task AlterHistory(Mock<IDateTimeOffsetProvider> mockDateTimeOffsetProvider, SqlConnection connection, string tableName)
+        async Task AlterHistory(Mock<IDateTimeOffsetProvider> mockDateTimeOffsetProvider, SqlConnection connection, string tableName)
         {
+
             var targetTime = mockDateTimeOffsetProvider.Object.GetCurrentUtcTime();
-
-            await AdjustTimeAsync(connection, "ValidFrom", tableName, targetTime, shouldUpdateValidTo: false);
-            await AdjustTimeAsync(connection, "ValidTo", $"{tableName}_History", targetTime, shouldUpdateValidTo: true);
-
-            static async Task AdjustTimeAsync(SqlConnection connection, string maxDateColumn, string tableNameToAdjust, DateTimeOffset targetTime, bool shouldUpdateValidTo)
-            {
-                ICollection<string> dateParts = ["YEAR", "MONTH", "HOUR", "MINUTE", "SECOND", "MICROSECOND", "NANOSECOND"];
-
-                foreach (var datePart in dateParts)
-                {
-                    var getHistorySql = $"""
-                        SELECT DATEDIFF_BIG({datePart}, MAX([{maxDateColumn}]), @CurrentTime)
-                        FROM [dbo].[{tableNameToAdjust}];
+            var getCurrentValidFromSql = $"""
+                        SELECT
+                            [ValidFrom]
+                        FROM
+                            [dbo].[{tableName}]
+                        WHERE
+                            [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey};
                         """;
-                    using var getHistoryCommand = new SqlCommand(getHistorySql, connection);
-                    getHistoryCommand.Parameters.Add(new SqlParameter("@CurrentTime", targetTime));
-                    var diff = await getHistoryCommand.ExecuteScalarAsync() as long?;
+            using var getCurrentValidFromCommand = new SqlCommand(getCurrentValidFromSql, connection);
+            getCurrentValidFromCommand.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", connectorEntityData.EntityId));
+            var validFrom = await getCurrentValidFromCommand.ExecuteScalarAsync() as DateTime?;
 
-                    if (diff == null)
-                    {
-                        continue;
-                    }
 
-                    var updateValidTo = shouldUpdateValidTo ? $",[ValidTo] = DATEADD({datePart}, @DateDiff, [ValidTo])" : string.Empty;
-                    var alterHistoryTimeSql = $"""
+            var updateCurrentValidFromToTimeSql = $"""
                     UPDATE
-                        [dbo].[{tableNameToAdjust}]
+                        [dbo].[{tableName}]
                     SET
-                        [ValidFrom] = DATEADD({datePart}, @DateDiff, [ValidFrom])
-                        {updateValidTo};
+                        [ValidFrom] = @ValidFrom
+                    WHERE
+                        [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey};
                     """;
-                    using var alterHistoryTimeCommand = new SqlCommand(alterHistoryTimeSql, connection)
-                    {
-                        CommandType = CommandType.Text,
-                    };
-                    alterHistoryTimeCommand.Parameters.Add(new SqlParameter("@DateDiff", diff));
-                    await alterHistoryTimeCommand.ExecuteNonQueryAsync();
-                }
-            }
-
-        }
-
-        static async Task AssertRowCount(SqlConnection connection, string tableName)
-        {
-            var getCountSql = $"SELECT COUNT(*) FROM [{tableName}]";
-            var sqlCommand = new SqlCommand(getCountSql, connection)
+            using var updateCurrentValidFromToTimeCommand = new SqlCommand(updateCurrentValidFromToTimeSql, connection)
             {
                 CommandType = CommandType.Text,
             };
-            var total = (int)await sqlCommand.ExecuteScalarAsync();
+            updateCurrentValidFromToTimeCommand.Parameters.Add(new SqlParameter("@ValidFrom", targetTime));
+            updateCurrentValidFromToTimeCommand.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", connectorEntityData.EntityId));
+            await updateCurrentValidFromToTimeCommand.ExecuteNonQueryAsync();
 
-            Assert.Equal(1, total);
+
+            var updateHistoryValidFromToTimeSql = $"""
+                    UPDATE
+                        [dbo].[{tableName}_History]
+                    SET
+                        [ValidTo] = @TargetValidTo
+                    WHERE
+                        [{DataLakeConstants.IdKey}] = @{DataLakeConstants.IdKey} AND
+                        [ValidTo] = @OriginalValidTo;
+                    """;
+            using var updateHistoryValidFromToTimeCommand = new SqlCommand(updateHistoryValidFromToTimeSql, connection)
+            {
+                CommandType = CommandType.Text,
+            };
+            updateHistoryValidFromToTimeCommand.Parameters.Add(new SqlParameter("@TargetValidTo", targetTime));
+            updateHistoryValidFromToTimeCommand.Parameters.Add(new SqlParameter("@OriginalValidTo", validFrom?.ToString("o")));
+            updateHistoryValidFromToTimeCommand.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", connectorEntityData.EntityId));
+            await updateHistoryValidFromToTimeCommand.ExecuteNonQueryAsync();
+
+            //await AdjustTimeAsync(connection, "ValidFrom", tableName, targetTime, shouldUpdateValidTo: false);
+            //await AdjustTimeAsync(connection, "ValidTo", $"{tableName}_History", targetTime, shouldUpdateValidTo: true);
+
+            //static async Task AdjustTimeAsync(SqlConnection connection, string maxDateColumn, string tableNameToAdjust, DateTimeOffset targetTime, bool shouldUpdateValidTo)
+            //{
+            //    ICollection<string> dateParts = ["YEAR", "MONTH", "HOUR", "MINUTE", "SECOND", "MICROSECOND", "NANOSECOND"];
+
+            //    foreach (var datePart in dateParts)
+            //    {
+            //        var getHistorySql = $"""
+            //            SELECT DATEDIFF_BIG({datePart}, MAX([{maxDateColumn}]), @CurrentTime)
+            //            FROM [dbo].[{tableNameToAdjust}];
+            //            """;
+            //        using var getHistoryCommand = new SqlCommand(getHistorySql, connection);
+            //        getHistoryCommand.Parameters.Add(new SqlParameter("@CurrentTime", targetTime));
+            //        var diff = await getHistoryCommand.ExecuteScalarAsync() as long?;
+
+            //        if (diff == null)
+            //        {
+            //            continue;
+            //        }
+
+            //        var updateValidTo = shouldUpdateValidTo ? $",[ValidTo] = DATEADD({datePart}, @DateDiff, [ValidTo])" : string.Empty;
+            //        var alterHistoryTimeSql = $"""
+            //        UPDATE
+            //            [dbo].[{tableNameToAdjust}]
+            //        SET
+            //            [ValidFrom] = DATEADD({datePart}, @DateDiff, [ValidFrom])
+            //            {updateValidTo};
+            //        """;
+            //        using var alterHistoryTimeCommand = new SqlCommand(alterHistoryTimeSql, connection)
+            //        {
+            //            CommandType = CommandType.Text,
+            //        };
+            //        alterHistoryTimeCommand.Parameters.Add(new SqlParameter("@DateDiff", diff));
+            //        await alterHistoryTimeCommand.ExecuteNonQueryAsync();
+            //    }
+            //}
         }
     }
+
+
 
     private protected virtual async Task AssertCsvResultUnescaped(DataLakeFileClient fileClient, DataLakeFileSystemClient dataLakeFileSystemClient, SetupContainerResult setupContainerResult)
     {
@@ -718,8 +741,8 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
     private void AssertResult(List<DataRow> actualRows, List<DataRow> expectedRows)
     {
         TestOutputHelper.WriteLine("Actual"  + Environment.NewLine + JsonConvert.SerializeObject(actualRows, Formatting.Indented));
-        TestOutputHelper.WriteLine("Expected" + Environment.NewLine + JsonConvert.SerializeObject(actualRows, Formatting.Indented));
-        Assert.Equal(actualRows.Count, actualRows.Count);
+        TestOutputHelper.WriteLine("Expected" + Environment.NewLine + JsonConvert.SerializeObject(expectedRows, Formatting.Indented));
+        Assert.Equal(actualRows.Count, expectedRows.Count);
         for (var i = 0; i < expectedRows.Count; i++)
         {
             var expectedRow = expectedRows[i];
@@ -1113,7 +1136,8 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
             string FileSystemName,
             string DirectoryName,
             DataLakeServiceClient Client,
-            DataLakeExportEntitiesJobBase ExportJob);
+            DataLakeExportEntitiesJobBase ExportJob,
+            SetupContainerResult SetupContainerResult);
 
     private protected record UserData(
         string Name,

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
@@ -185,6 +185,8 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
         var connectorMock = GetConnectorMock(mockDateTimeOffsetProvider, constantsMock, jobDataFactoryMock);
         jobDataFactoryMock.Setup(x => x.GetConfiguration(It.IsAny<ExecutionContext>(), It.IsAny<IReadOnlyStreamModel>()))
             .ReturnsAsync(jobData);
+        jobDataFactoryMock.Setup(x => x.GetConfiguration(It.IsAny<ExecutionContext>(), It.IsAny<Guid>()))
+            .ReturnsAsync(jobData);
         connectorMock.CallBase = true;
 
         var (streamModel, streamRepositoryMock) = SetupStreamModel(organization, streamMode, providerDefinitionId, container);

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
@@ -6,8 +6,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-using Azure;
-using Azure.Storage;
 using Azure.Storage.Files.DataLake;
 using Azure.Storage.Files.DataLake.Models;
 
@@ -42,9 +40,6 @@ using Parquet;
 
 using Xunit;
 using Xunit.Abstractions;
-using Xunit.Sdk;
-
-using static CluedIn.Core.Constants.Configuration;
 
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 
@@ -502,6 +497,7 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
 
             DROP TABLE IF EXISTS [{tableName}];
             DROP TABLE IF EXISTS [{tableName}_History];
+            DROP TABLE IF EXISTS [{CacheTableHelper.GetExportHistoryTableName(streamId)}_ExportHistory];
             """;
         try
         {
@@ -509,11 +505,11 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
         }
         catch (SqlException ex) when (ex.Number == NotTemporalTableErrorCode)
         {
-            var historyTable = $"{tableName}_History";
             var deleteTableSeparatelySql = $"""
                 IF EXISTS (SELECT * FROM SYSOBJECTS WHERE NAME='{tableName}' AND XTYPE='U')
                 DROP TABLE IF EXISTS [{tableName}];
                 DROP TABLE IF EXISTS [{tableName}_History];
+                DROP TABLE IF EXISTS [{CacheTableHelper.GetExportHistoryTableName(streamId)}_ExportHistory];
                 """;
             await DeleteTableInternal(deleteTableSeparatelySql, streamCacheConnectionString);
         }
@@ -650,45 +646,6 @@ public abstract partial class DataLakeConnectorTestsBase<TConnector, TJobDataFac
             updateHistoryValidFromToTimeCommand.Parameters.Add(new SqlParameter("@OriginalValidTo", validFrom?.ToString("o")));
             updateHistoryValidFromToTimeCommand.Parameters.Add(new SqlParameter($"@{DataLakeConstants.IdKey}", connectorEntityData.EntityId));
             await updateHistoryValidFromToTimeCommand.ExecuteNonQueryAsync();
-
-            //await AdjustTimeAsync(connection, "ValidFrom", tableName, targetTime, shouldUpdateValidTo: false);
-            //await AdjustTimeAsync(connection, "ValidTo", $"{tableName}_History", targetTime, shouldUpdateValidTo: true);
-
-            //static async Task AdjustTimeAsync(SqlConnection connection, string maxDateColumn, string tableNameToAdjust, DateTimeOffset targetTime, bool shouldUpdateValidTo)
-            //{
-            //    ICollection<string> dateParts = ["YEAR", "MONTH", "HOUR", "MINUTE", "SECOND", "MICROSECOND", "NANOSECOND"];
-
-            //    foreach (var datePart in dateParts)
-            //    {
-            //        var getHistorySql = $"""
-            //            SELECT DATEDIFF_BIG({datePart}, MAX([{maxDateColumn}]), @CurrentTime)
-            //            FROM [dbo].[{tableNameToAdjust}];
-            //            """;
-            //        using var getHistoryCommand = new SqlCommand(getHistorySql, connection);
-            //        getHistoryCommand.Parameters.Add(new SqlParameter("@CurrentTime", targetTime));
-            //        var diff = await getHistoryCommand.ExecuteScalarAsync() as long?;
-
-            //        if (diff == null)
-            //        {
-            //            continue;
-            //        }
-
-            //        var updateValidTo = shouldUpdateValidTo ? $",[ValidTo] = DATEADD({datePart}, @DateDiff, [ValidTo])" : string.Empty;
-            //        var alterHistoryTimeSql = $"""
-            //        UPDATE
-            //            [dbo].[{tableNameToAdjust}]
-            //        SET
-            //            [ValidFrom] = DATEADD({datePart}, @DateDiff, [ValidFrom])
-            //            {updateValidTo};
-            //        """;
-            //        using var alterHistoryTimeCommand = new SqlCommand(alterHistoryTimeSql, connection)
-            //        {
-            //            CommandType = CommandType.Text,
-            //        };
-            //        alterHistoryTimeCommand.Parameters.Add(new SqlParameter("@DateDiff", diff));
-            //        await alterHistoryTimeCommand.ExecuteNonQueryAsync();
-            //    }
-            //}
         }
     }
 

--- a/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
+++ b/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
@@ -201,7 +201,10 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
     [Fact]
     public async Task VerifyStoreData_Sync_WhenRepeatRunAndFileExistsUsingInternalSchedulerAndDifferentDataTime_CanCreateNewFile()
     {
+        var initialUserData = UserData.Default;
+        var firstChangeUserData = initialUserData with { Age = initialUserData.Age + 1 };
         var executionCount = 0;
+        var storeDataCount = 0;
         var dateTimeList = new List<DateTimeOffset>
         {
             DefaultCurrentTime,
@@ -209,9 +212,23 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
         };
         await VerifyStoreData_Sync_WithStreamCache(
             "parquet",
-            AssertParquetResultEscapedWithRowMarker,
+            async (fileClient, _, setupResult) =>
+            {
+                var dateTimeProvider = setupResult.DateTimeOffsetProviderMock.Object;
+                await base.AssertParquetResult(fileClient, separator: "_", isArrayColumnEnabled: false, formatResult: (original) =>
+                {
+                    var updated = original.ToList();
+                    updated[0].Columns["__rowMarker__"] = "4";
+                    updated[0].Columns["Timestamp"] = dateTimeProvider.GetCurrentUtcTime().ToString("O");
+                    updated[0].Columns["Epoch"] = dateTimeProvider.GetCurrentUtcTime().ToUnixTimeMilliseconds();
+                    updated[0].Columns[DataLakeConstants.PersistVersionKey] = 2;
+                    updated[0].Columns["user_age"] = firstChangeUserData.Age.ToString();
+                    return updated;
+                });
+            },
             async executeExportArg =>
             {
+                executionCount = 0;
                 var jobArgs = new DataLakeJobArgs
                 {
                     OrganizationId = executeExportArg.Organization.Id.ToString(),
@@ -255,6 +272,23 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
                     {
                         return dateTimeList[executionCount];
                     });
+            },
+            storeData: async (setupResult, data) =>
+            {
+                await setupResult.ConnectorMock.Object.StoreData(setupResult.Context, setupResult.StreamModel, data);
+                await ModifyHistoryTimeToBeCurrentTime(setupResult, data);
+                if (storeDataCount == 0)
+                {
+                    executionCount++;
+                }
+                storeDataCount++;
+            },
+            getConnectorEntityData: () =>
+            {
+                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
+                var firstChangeEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 2, userData: firstChangeUserData);
+
+                return new[] { initialEntityData, firstChangeEntityData };
             });
     }
 
@@ -447,6 +481,7 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
         Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
         Action<Dictionary<string, object>> configureAuthentication = null,
         Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<SetupContainerResult, ConnectorEntityData, Task> storeData = null,
         Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null)
     {
         var configuration = CreateConfigurationWithStreamCache(format);
@@ -461,7 +496,14 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
             : getConnectorEntityData();
         foreach (var data in connectorEntityData)
         {
+            if (storeData != null)
+            {
+                await storeData(setupResult, data);
+                continue;
+            }
+
             await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+            await ModifyHistoryTimeToBeCurrentTime(setupResult, data);
         }
         var exportJob = CreateExportJob(setupResult);
 

--- a/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
+++ b/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
@@ -13,6 +13,7 @@ using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Connector.DataLake.Common.Tests.Integration;
 using CluedIn.Connector.FabricOpenMirroring.Connector;
 using CluedIn.Core;
+using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
 
@@ -439,13 +440,14 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
         });
     }
 
-    private async Task VerifyStoreData_Sync_WithStreamCache(
+    private protected override async Task VerifyStoreData_Sync_WithStreamCache(
         string format,
         Func<DataLakeFileClient, DataLakeFileSystemClient, SetupContainerResult, Task> assertMethod,
         Func<ExecuteExportArg, Task<PathItem>> executeExport = null,
         Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
         Action<Dictionary<string, object>> configureAuthentication = null,
-        Func<OpenMirroringConnectorJobData, SetupContainerResult, string> configureDirectoryName = null)
+        Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null)
     {
         var configuration = CreateConfigurationWithStreamCache(format);
         configureAuthentication?.Invoke(configuration);
@@ -454,8 +456,13 @@ public class OpenMirroringConnectorTests : DataLakeConnectorTestsBase<OpenMirror
         var setupResult = await SetupContainer(jobData, StreamMode.Sync, configureTimeProvider);
         var connector = setupResult.ConnectorMock.Object;
 
-        var data = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added);
-        await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+        var connectorEntityData = getConnectorEntityData == null
+            ? [CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added)]
+            : getConnectorEntityData();
+        foreach (var data in connectorEntityData)
+        {
+            await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+        }
         var exportJob = CreateExportJob(setupResult);
 
         var directoryName = configureDirectoryName == null

--- a/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
+++ b/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
@@ -17,6 +17,8 @@ using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
 
+using Hangfire.Storage;
+
 using Microsoft.Extensions.Logging;
 
 using Moq;
@@ -502,6 +504,7 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
         Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
         Action<Dictionary<string, object>> configureAuthentication = null,
         Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<SetupContainerResult, ConnectorEntityData, Task> storeData = null,
         Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null)
     {
         var configuration = CreateConfigurationWithStreamCache(format);
@@ -516,7 +519,14 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
             : getConnectorEntityData();
         foreach (var data in connectorEntityData)
         {
+            if (storeData != null)
+            {
+                await storeData(setupResult, data);
+                continue;
+            }
+
             await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+            await ModifyHistoryTimeToBeCurrentTime(setupResult, data);
         }
         var exportJob = CreateExportJob(setupResult);
 
@@ -528,6 +538,36 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
             exportJob,
             assertMethod,
             executeExport);
+    }
+
+    [Fact]
+    public async Task VerifyStoreData_Sync_WithStreamCacheCanIgnoreWhenChangedAfterDeletion()
+    {
+        await VerifyStoreData_Sync_WithStreamCache("csv",
+            async (fileClient, _, _) => await AssertCsvResult(fileClient, "_", (rows) =>
+            {
+                var removed = rows.ToList();
+                removed.Clear();
+                return removed;
+            }),
+            getConnectorEntityData: () =>
+            {
+                var initialUserData = UserData.Default;
+                var removedUserData = initialUserData with { Age = initialUserData.Age + 1 };
+                var readdAfterDeletionUserData = initialUserData with { Age = initialUserData.Age + 2 };
+
+                var initialEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added, persistVersion: 1, userData: initialUserData);
+                var removedEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Removed, persistVersion: 2, userData: removedUserData);
+                var readdAfterDeletionEntityData = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Changed, persistVersion: 3, userData: readdAfterDeletionUserData);
+
+                // Intermediate version is outdated when final version is stored, so it should be ignored and not cause the export to fail
+                return new[] { initialEntityData, removedEntityData, readdAfterDeletionEntityData };
+            },
+            configureAuthentication: (values) =>
+            {
+                values.Add(nameof(DataLakeConstants.ShouldEscapeVocabularyKeys), true);
+                values.Add(nameof(DataLakeConstants.ShouldWriteGuidAsString), true);
+            });
     }
 
     private protected override DataLakeExportEntitiesJobBase CreateExportJob(SetupContainerResult setupResult)

--- a/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
+++ b/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
@@ -17,8 +17,6 @@ using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
 
-using Hangfire.Storage;
-
 using Microsoft.Extensions.Logging;
 
 using Moq;

--- a/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
+++ b/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
@@ -13,6 +13,7 @@ using CluedIn.Connector.DataLake.Common.Connector;
 using CluedIn.Connector.DataLake.Common.Tests.Integration;
 using CluedIn.Connector.OneLake.Connector;
 using CluedIn.Core;
+using CluedIn.Core.Connectors;
 using CluedIn.Core.Data.Parts;
 using CluedIn.Core.Streams.Models;
 
@@ -494,12 +495,14 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
             });
     }
 
-    private async Task VerifyStoreData_Sync_WithStreamCache(
+    private protected override async Task VerifyStoreData_Sync_WithStreamCache(
         string format,
         Func<DataLakeFileClient, DataLakeFileSystemClient, SetupContainerResult, Task> assertMethod,
         Func<ExecuteExportArg, Task<PathItem>> executeExport = null,
         Action<Mock<IDateTimeOffsetProvider>> configureTimeProvider = null,
-        Action<Dictionary<string, object>> configureAuthentication = null)
+        Action<Dictionary<string, object>> configureAuthentication = null,
+        Func<IEnumerable<ConnectorEntityData>> getConnectorEntityData = null,
+        Func<IDataLakeJobData, SetupContainerResult, string> configureDirectoryName = null)
     {
         var configuration = CreateConfigurationWithStreamCache(format);
         configureAuthentication?.Invoke(configuration);
@@ -508,8 +511,13 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
         var setupResult = await SetupContainer(jobData, StreamMode.Sync, configureTimeProvider);
         var connector = setupResult.ConnectorMock.Object;
 
-        var data = CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added);
-        await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+        var connectorEntityData = getConnectorEntityData == null
+            ? [CreateBaseConnectorEntityData(StreamMode.Sync, VersionChangeType.Added)]
+            : getConnectorEntityData();
+        foreach (var data in connectorEntityData)
+        {
+            await connector.StoreData(setupResult.Context, setupResult.StreamModel, data);
+        }
         var exportJob = CreateExportJob(setupResult);
 
         await AssertExportJobOutputFileContents(


### PR DESCRIPTION


<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#55463](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/55463) [AB#56076](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56076)


This branch focuses on preventing race conditions that cause inconsistent state in the stream cache by introducing persist version checking during data updates. Key changes include:
Core Fix: Persist Version Checking
•	Soft deletes with version guards: The connector now always uses soft deletes and checks the PersistVersion when updating/deleting rows in the stream cache. This prevents out-of-order or stale updates from overwriting newer data — e.g., a "Changed" event arriving after a "Removed" event for the same entity won't incorrectly resurrect it.
Stream Cache Table Migration
•	DataLakeDataMigrator was updated to migrate existing stream cache tables, likely to add the PersistVersion column or adjust temporal table settings to support the new versioning logic.
Authentication Override via Connector Properties
•	Allows overriding authentication details (e.g., credentials) using connector properties, giving more flexibility in configuration.
•	Migrates existing export targets to use hard deletes (likely for the actual data lake output, distinct from the soft-delete approach in the cache).
Test Improvements
•	Added LegacyBufferTests for buffer behavior verification.
•	New integration test (VerifyStoreData_Sync_WithStreamCacheCanIgnoreWhenChangedAfterDeletion()) that validates the race condition fix: when an entity is added, removed, then re-added with increasing persist versions, intermediate outdated versions are correctly ignored.
•	Test infrastructure extended to support custom getConnectorEntityData, StoreData(ExecutionContext, IReadOnlyStreamModel, IReadOnlyConnectorEntityData), and configureDirectoryName parameters.


## How has it been tested? <!-- Remove if not needed -->


## Release Note <!-- Remove if not needed -->


## Notable Changes <!-- Remove if not needed -->
