### PR TITLE
fix: Healthcheck to check for lakehouse existence

### DIFF
--- a/docs/4.6.5-release-notes.md
+++ b/docs/4.6.5-release-notes.md
@@ -1,0 +1,4 @@
+### Features
+
+### Fixes
+Fix health check not checking existence of lakehouse

--- a/src/Connector.DataLake.Common/Connector/DataLakeClient.cs
+++ b/src/Connector.DataLake.Common/Connector/DataLakeClient.cs
@@ -152,12 +152,11 @@ namespace CluedIn.Connector.DataLake.Common.Connector
         {
             var directory = configuration.RootDirectoryPath;
             var directoryClient = fileSystemClient.GetDirectoryClient(directory);
-            if (string.IsNullOrWhiteSpace(subDirectory))
+            if (!string.IsNullOrWhiteSpace(subDirectory))
             {
-                return directoryClient;
+                directoryClient = directoryClient.GetSubDirectoryClient(subDirectory);
             }
 
-            directoryClient = directoryClient.GetSubDirectoryClient(subDirectory);
 
             if (ensureExists && !await directoryClient.ExistsAsync())
             {

--- a/src/Connector.OneLake/Connector/OneLakeConnector.cs
+++ b/src/Connector.OneLake/Connector/OneLakeConnector.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -22,6 +22,8 @@ public class OneLakeConnector : DataLakeConnector
     internal const string InvalidFolderErrorMessage = "Invalid Folder. It has to start with Files.";
 
     internal const string WorkspaceNotFoundErrorCode = "WorkspaceNotFound";
+    internal const string ArtifactNotFoundErrorMessageFormat = "Item '{0}' with type '{1}' is not found.";
+    internal const string ArtifactNotFoundErrorCode = "ArtifactNotFound";
     private readonly ILogger<OneLakeConnector> _logger;
 
     public OneLakeConnector(
@@ -65,6 +67,12 @@ public class OneLakeConnector : DataLakeConnector
         {
             var errorMessage = WorkspaceNotFoundErrorMessageFormat.FormatWith(casted.WorkspaceName);
             _logger.LogWarning(ex, WorkspaceNotFoundErrorMessageFormat, casted?.WorkspaceName);
+            return CreateFailedConnectionVerification(errorMessage);
+        }
+        catch (RequestFailedException ex) when (ArtifactNotFoundErrorCode.Equals(ex.ErrorCode))
+        {
+            var errorMessage = ArtifactNotFoundErrorMessageFormat.FormatWith(casted.ItemName, casted.ItemType);
+            _logger.LogWarning(ex, ArtifactNotFoundErrorMessageFormat, casted.ItemName, casted.ItemType);
             return CreateFailedConnectionVerification(errorMessage);
         }
         catch (Exception ex)

--- a/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
+++ b/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -139,6 +138,23 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
         Assert.NotNull(result);
         Assert.False(result.Success);
         Assert.Equal(OneLakeConnector.WorkspaceNotFoundErrorMessageFormat.FormatWith("1"), result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task VerifyConnection_WhenItemNotFound_ReturnItemNotFoundErrorMessage()
+    {
+        var configuration = CreateConfigurationWithoutStreamCache();
+        configuration[nameof(OneLakeConstants.ItemName)] = "NonExistent";
+        var jobData = new OneLakeConnectorJobData(configuration);
+
+        var setupResult = await SetupContainer(jobData, StreamMode.EventStream);
+        var connector = setupResult.ConnectorMock.Object;
+        setupResult.JobDataFactoryMock.Setup(factory => factory.GetConfiguration(setupResult.Context, configuration, It.IsAny<string>()))
+            .Returns(Task.FromResult<IDataLakeJobData>(jobData));
+        var result = await connector.VerifyConnection(setupResult.Context, configuration);
+        Assert.NotNull(result);
+        Assert.False(result.Success);
+        Assert.Equal(OneLakeConnector.ArtifactNotFoundErrorMessageFormat.FormatWith(jobData.ItemName, jobData.ItemType), result.ErrorMessage);
     }
 
     [Theory]


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: AB#56935

On some customer environments, when a OneLake lakehouse artifact does not exist in the configured workspace, a `RequestFailedException` with error code `ArtifactNotFound` was being thrown during data export. This resulted in an unhandled exception being logged as an error every minute.

This PR adds proper handling for the `ArtifactNotFound` error code in `OneLakeConnector.VerifyDataLakeConnection`, returning a clear, user-friendly connection verification failure message instead of propagating the exception.

Additionally, a pre-existing bug was fixed in `DataLakeClient.GetDirectoryClientAsync` where the subdirectory condition was inverted — causing `GetSubDirectoryClient` to never be called when a subdirectory was provided.

## How has it been tested?
- A new integration test `VerifyConnection_WhenItemNotFound_ReturnItemNotFoundErrorMessage` was added to `OneLakeConnectorTests` to verify the `ArtifactNotFound` error path returns the correct failure message.

## Release Note
Fixed an issue where OneLake connectors would repeatedly log unhandled exceptions when the configured lakehouse artifact does not exist. The connection verification now returns a descriptive error message (`Item '{name}' with type '{type}' is not found.`) instead.

## Notable Changes
- `OneLakeConnector`: Added `catch` block for `RequestFailedException` with `ArtifactNotFound` error code in `VerifyDataLakeConnection`.
- `DataLakeClient`: Fixed inverted subdirectory condition in `GetDirectoryClientAsync` — `GetSubDirectoryClient` is now correctly called only when `subDirectory` is not null or whitespace.