### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>12.0</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Metadata">

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
 # GitVersion.yml
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   master:
     mode: ContinuousDelivery

--- a/Packages.props
+++ b/Packages.props
@@ -9,6 +9,7 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
+    <PackageReference Update="Azure.Identity" Version="1.21.0" />
     <PackageReference Update="Azure.Storage.Files.DataLake" Version="12.22.0" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
   </ItemGroup>

--- a/Packages.props
+++ b/Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_CluedIn>4.7.1</_CluedIn>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,12 +19,12 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Update="AutoFixture.Xunit2" Version="4.11.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Update="AutoFixture.Xunit3" Version="5.0.0-preview0012" />
     <PackageReference Update="coverlet.msbuild" Version="2.8.0" />
     <PackageReference Update="CsvHelper" Version="15.0.0" />
-    <PackageReference Update="xunit" Version="2.4.1" />
-    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Update="xunit.v3" Version="3.2.2" />
+    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Update="Moq" Version="4.13.1" />
     <PackageReference Update="NCrontab" Version="3.3.3" />
     <PackageReference Update="Parquet.Net" Version="4.23.5" />

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/Connector.AzureAIStudio/Connector.AzureAIStudio.csproj
+++ b/src/Connector.AzureAIStudio/Connector.AzureAIStudio.csproj
@@ -12,6 +12,7 @@
     <EmbeddedResource Include="Resources\azureaistudio.svg" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\Connector.DataLake.Common\Connector.DataLake.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Connector.AzureDatabricks/Connector.AzureDatabricks.csproj
+++ b/src/Connector.AzureDatabricks/Connector.AzureDatabricks.csproj
@@ -12,6 +12,7 @@
     <EmbeddedResource Include="Resources\azuredatabricks.svg" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\Connector.DataLake.Common\Connector.DataLake.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Connector.FabricOpenMirroring/Connector.FabricOpenMirroring.csproj
+++ b/src/Connector.FabricOpenMirroring/Connector.FabricOpenMirroring.csproj
@@ -15,6 +15,7 @@
     <EmbeddedResource Include="Resources\fabricOpenMirroring.svg" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\Connector.DataLake.Common\Connector.DataLake.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Connector.OneLake/Connector.OneLake.csproj
+++ b/src/Connector.OneLake/Connector.OneLake.csproj
@@ -15,6 +15,7 @@
     <EmbeddedResource Include="Resources\onelake.svg" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\Connector.DataLake.Common\Connector.DataLake.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Connector.SynapseDataEngineering/Connector.SynapseDataEngineering.csproj
+++ b/src/Connector.SynapseDataEngineering/Connector.SynapseDataEngineering.csproj
@@ -12,6 +12,7 @@
     <EmbeddedResource Include="Resources\synapsedataengineering.svg" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
     <ProjectReference Include="..\Connector.DataLake.Common\Connector.DataLake.Common.csproj" />
   </ItemGroup>
 </Project>

--- a/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
+++ b/test/integration/Connector.AzureDataLake.Tests.Integration/AzureDataLakeConnectorTests.cs
@@ -23,7 +23,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 
 using Xunit;
-using Xunit.Abstractions;
 
 using Encoding = System.Text.Encoding;
 
@@ -271,7 +270,7 @@ public class AzureDataLakeConnectorTests : DataLakeConnectorTestsBase<AzureDataL
     }
 
     [Fact]
-    public async void VerifyStoreData_Sync_WithoutStreamCache()
+    public async Task VerifyStoreData_Sync_WithoutStreamCache()
     {
         var configuration = CreateConfigurationWithoutStreamCache();
         var jobData = new AzureDataLakeConnectorJobData(configuration);

--- a/test/integration/Connector.AzureDataLake.Tests.Integration/Connector.AzureDataLake.Tests.Integration.csproj
+++ b/test/integration/Connector.AzureDataLake.Tests.Integration/Connector.AzureDataLake.Tests.Integration.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
     <PackageReference Include="ParquetSharp" />

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/Connector.DataLake.Common.Tests.Integration.csproj
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/Connector.DataLake.Common.Tests.Integration.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="Moq" />
     <PackageReference Include="ParquetSharp" />
     <PackageReference Include="CsvHelper" />

--- a/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
+++ b/test/integration/Connector.DataLake.Common.Tests.Integration/DataLakeConnectorTestsBase.cs
@@ -40,7 +40,6 @@ using Newtonsoft.Json.Linq;
 using Parquet;
 
 using Xunit;
-using Xunit.Abstractions;
 
 using ExecutionContext = CluedIn.Core.ExecutionContext;
 

--- a/test/integration/Connector.FabricOpenMirroring.Tests.Integration/Connector.FabricOpenMirroring.Tests.Integration.csproj
+++ b/test/integration/Connector.FabricOpenMirroring.Tests.Integration/Connector.FabricOpenMirroring.Tests.Integration.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
     <PackageReference Include="ParquetSharp" />

--- a/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
+++ b/test/integration/Connector.FabricOpenMirroring.Tests.Integration/FabricOpenMirroringConnectorTests.cs
@@ -21,7 +21,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 
 using Xunit;
-using Xunit.Abstractions;
 
 using Encoding = System.Text.Encoding;
 

--- a/test/integration/Connector.OneLake.Tests.Integration/Connector.OneLake.Tests.Integration.csproj
+++ b/test/integration/Connector.OneLake.Tests.Integration/Connector.OneLake.Tests.Integration.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
     <PackageReference Include="ParquetSharp" />

--- a/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
+++ b/test/integration/Connector.OneLake.Tests.Integration/OneLakeConnectorTests.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Logging;
 using Moq;
 
 using Xunit;
-using Xunit.Abstractions;
 
 using Encoding = System.Text.Encoding;
 
@@ -223,7 +222,7 @@ public class OneLakeConnectorTests : DataLakeConnectorTestsBase<OneLakeConnector
     }
 
     [Fact]
-    public async void VerifyStoreData_Sync_WithoutStreamCache()
+    public async Task VerifyStoreData_Sync_WithoutStreamCache()
     {
         var configuration = CreateConfigurationWithoutStreamCache();
         var jobData = new OneLakeConnectorJobData(configuration);

--- a/test/unit/Connector.AzureDataLake.Tests.Unit/Connector.AzureDataLake.Tests.Unit.csproj
+++ b/test/unit/Connector.AzureDataLake.Tests.Unit/Connector.AzureDataLake.Tests.Unit.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
   </ItemGroup>

--- a/test/unit/Connector.DataLake.Common.Tests.Unit/Connector.DataLake.Common.Tests.Unit.csproj
+++ b/test/unit/Connector.DataLake.Common.Tests.Unit/Connector.DataLake.Common.Tests.Unit.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" />
+    <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="coverlet.msbuild" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Moq" />
   </ItemGroup>


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`
- `Packages.props`: Added `Azure.Identity 1.13.2` explicit version
- xunit migrated from v2 to `xunit.v3 3.2.2`; `AutoFixture.Xunit2` → `AutoFixture.Xunit3 5.0.0-preview0012`
- Test methods migrated from `async void` to `async Task`