### PR TITLE
fix: Prevent error when starting OpenFabricMIrroring due to missing depedencies

### DIFF
--- a/src/Connector.FabricOpenMirroring/EventHandlers/ExportTargetEventHandler.cs
+++ b/src/Connector.FabricOpenMirroring/EventHandlers/ExportTargetEventHandler.cs
@@ -27,22 +27,15 @@ internal class ExportTargetEventHandler : IDisposable
         ILogger<ExportTargetEventHandler> logger,
         ApplicationContext applicationContext,
         IStorageConfigurationConstants constants,
-        IStorageFactory jobDataFactory,
-        OpenMirroringStorageClient openMirroringStorageDataLakeClient)
+        IStorageFactory jobDataFactory)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _applicationContext = applicationContext ?? throw new ArgumentNullException(nameof(applicationContext));
         _configurationConstants = constants ?? throw new ArgumentNullException(nameof(constants));
         _storageFactory = jobDataFactory ?? throw new ArgumentNullException(nameof(jobDataFactory));
 
-        _registerExportTargetSubscription = applicationContext.System.Events.Local.Subscribe<RegisterExportTargetEvent>(ProcessEvent);
-        _updateExportTargetSubscription = applicationContext.System.Events.Local.Subscribe<UpdateExportTargetEvent>(ProcessEvent);
-    }
-
-    private void ProcessEvent<TEvent>(TEvent eventData)
-        where TEvent : RemoteEvent
-    {
-        ProcessEventAsync(eventData).GetAwaiter().GetResult();
+        _registerExportTargetSubscription = applicationContext.System.Events.Local.SubscribeAsync<RegisterExportTargetEvent>(ProcessEventAsync);
+        _updateExportTargetSubscription = applicationContext.System.Events.Local.SubscribeAsync<UpdateExportTargetEvent>(ProcessEventAsync);
     }
 
     private async Task ProcessEventAsync<TEvent>(TEvent eventData)

--- a/src/Connector.FabricOpenMirroring/OpenMirroringConnectorComponent.cs
+++ b/src/Connector.FabricOpenMirroring/OpenMirroringConnectorComponent.cs
@@ -35,9 +35,7 @@ public sealed class OpenMirroringConnectorComponent : StorageConnectorComponentB
     private protected override void SubscribeToEvents(IStorageConfigurationConstants constants, IStorageFactory storageFactory, IScheduledJobQueue jobQueue)
     {
         var logger = Container.Resolve<ILogger<ExportTargetEventHandler>>();
-        var dateTimeProvider = Container.Resolve<IDateTimeOffsetProvider>();
-        var fabricClient = Container.Resolve<OpenMirroringStorageClient>();
-        _exportTargetEventHandler = new(logger, ApplicationContext, constants, storageFactory, fabricClient);
+        _exportTargetEventHandler = new(logger, ApplicationContext, constants, storageFactory);
         base.SubscribeToEvents(constants, storageFactory, jobQueue);
     }
 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#56392](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56392)


## How has it been tested? <!-- Remove if not needed -->
Locally, manually

## Release Note <!-- Remove if not needed -->


## Notable Changes <!-- Remove if not needed -->
